### PR TITLE
Git ignore service registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ venv
 # PyCharm IDE
 
 .idea
+
+# Service registry
+
+service_registry.db**


### PR DESCRIPTION
We don't need to track the service registry .db files.