### PR TITLE
Load characterisation test setup values as default UI input fields

### DIFF
--- a/src/tvac/tasks/tvac/piezos/__init__.py
+++ b/src/tvac/tasks/tvac/piezos/__init__.py
@@ -28,6 +28,36 @@ def piezos() -> List[str]:
     return piezo_list
 
 
+def _sine_sweep_param(param: str) -> float:
+    """Get a sine sweep parameter value from the Setup configuration."""
+    setup = load_setup()
+    return float(getattr(setup.gse.wave_generators.piezo_tests.sine_sweep, param))
+
+
+def sine_sweep_amplitude() -> float:
+    return _sine_sweep_param("amplitude")
+
+
+def sine_sweep_dc_offset() -> float:
+    return _sine_sweep_param("dc_offset")
+
+
+def sine_sweep_start_frequency() -> float:
+    return _sine_sweep_param("start_frequency")
+
+
+def sine_sweep_stop_frequency() -> float:
+    return _sine_sweep_param("stop_frequency")
+
+
+def sine_sweep_time() -> float:
+    return _sine_sweep_param("sweep_time")
+
+
+def sine_sweep_fixed_voltage() -> float:
+    return _sine_sweep_param("fixed_voltage")
+
+
 def piezos_incl_all() -> List[str]:
     """Names of the piezo actuators.  Each of them has a dedicated channel in a dedicated wave generator."""
 

--- a/src/tvac/tasks/tvac/piezos/characterization.py
+++ b/src/tvac/tasks/tvac/piezos/characterization.py
@@ -4,6 +4,14 @@ from gui_executor.exec import exec_ui
 from gui_executor.utypes import Callback
 
 from tvac.tasks.tvac.piezos import piezos
+from tvac.tasks.tvac.piezos import (
+    sine_sweep_amplitude,
+    sine_sweep_dc_offset,
+    sine_sweep_start_frequency,
+    sine_sweep_stop_frequency,
+    sine_sweep_time,
+    sine_sweep_fixed_voltage,
+)
 from tvac.wave_generation import characterize_piezo
 
 UI_MODULE_DISPLAY_NAME = "1 - Characterisation"
@@ -12,12 +20,12 @@ UI_MODULE_DISPLAY_NAME = "1 - Characterisation"
 @exec_ui(display_name="Start characterisation", use_kernel=True)
 def start_piezo_characterization(
     piezo: Callback(piezos, name="Piezo actuator to sweep") = None,
-    amplitude: Callback(float, name="Amplitude for frequency sweep [Vpp]") = 0.2,
-    dc_offset: Callback(float, name="DC offset for frequency sweep [Vdc]") = 0.15,
-    start_frequency: Callback(float, name="Sweep start frequency [Hz]") = 1,
-    stop_frequency: Callback(float, name="Sweep stop frequency [Hz]") = 1500,
-    sweep_time: Callback(float, name="Sweep time [s]") = 40,
-    fixed_voltage: Callback(float, name="Constant voltage (other piezos) [Vdc]") = 0.15,
+    amplitude: Callback(sine_sweep_amplitude, name="Amplitude for frequency sweep [Vpp]") = None,
+    dc_offset: Callback(sine_sweep_dc_offset, name="DC offset for frequency sweep [Vdc]") = None,
+    start_frequency: Callback(sine_sweep_start_frequency, name="Sweep start frequency [Hz]") = None,
+    stop_frequency: Callback(sine_sweep_stop_frequency, name="Sweep stop frequency [Hz]") = None,
+    sweep_time: Callback(sine_sweep_time, name="Sweep time [s]") = None,
+    fixed_voltage: Callback(sine_sweep_fixed_voltage, name="Constant voltage (other piezos) [Vdc]") = None,
 ):
     """Charactersisation of the given piezo actuator.
 


### PR DESCRIPTION
In setup 6, we've added parameters for the sine sweep for the characterisation test. This PR takes those setup values and uses them as default values for the characterisation arguments.

<img width="600" height="828" alt="image" src="https://github.com/user-attachments/assets/93738324-d3fd-47b2-af8b-8cfbb8bbdb36" />
