### PR TITLE
Use callbacks for SG UI input widgets

### DIFF
--- a/src/tvac/tasks/tvac/strain_gauges/__init__.py
+++ b/src/tvac/tasks/tvac/strain_gauges/__init__.py
@@ -2,6 +2,8 @@ from typing import List
 
 from egse.setup import load_setup
 
+from tvac.strain_gauge import get_sg_effective_settings
+
 UI_TAB_DISPLAY_NAME = "Strain Gauges"
 
 
@@ -11,3 +13,53 @@ def strain_gauges() -> List[str]:
     setup = load_setup()
 
     return list(setup.gse.labjack_t7.channels.keys())
+
+
+# Stream callbacks
+
+def sg_scan_rate() -> float:
+    return float(get_sg_effective_settings()["stream"]["scan_rate"])
+
+
+def sg_resync_interval_s() -> int:
+    return int(get_sg_effective_settings()["stream"]["resync_interval_s"])
+
+
+def sg_buffer_size() -> int:
+    return int(get_sg_effective_settings()["stream"]["buffer_size"])
+
+
+# CSV callbacks
+
+def sg_csv_enabled() -> bool:
+    return bool(get_sg_effective_settings()["csv"]["enabled"])
+
+
+def sg_csv_save_path() -> str:
+    return str(get_sg_effective_settings()["csv"]["save_path"])
+
+
+def sg_csv_base_filename() -> str:
+    return str(get_sg_effective_settings()["csv"]["base_filename"])
+
+
+def sg_csv_max_file_size_bytes() -> int:
+    return int(get_sg_effective_settings()["csv"]["max_file_size_bytes"])
+
+
+# Plot callbacks
+
+def sg_plot_enabled() -> bool:
+    return bool(get_sg_effective_settings()["plot"]["enabled"])
+
+
+def sg_plot_window_seconds() -> float:
+    return float(get_sg_effective_settings()["plot"]["window_seconds"])
+
+
+def sg_plot_interval_ms() -> int:
+    return int(get_sg_effective_settings()["plot"]["interval_ms"])
+
+
+def sg_plot_show_stats() -> bool:
+    return bool(get_sg_effective_settings()["plot"]["show_stats"])

--- a/src/tvac/tasks/tvac/strain_gauges/strain_gauges.py
+++ b/src/tvac/tasks/tvac/strain_gauges/strain_gauges.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
-from PyQt5.QtWidgets import QCheckBox, QComboBox, QHBoxLayout, QLineEdit
+from PyQt5.QtWidgets import QCheckBox, QComboBox, QHBoxLayout
 from egse.setup import load_setup
 from gui_executor.exec import exec_ui
-from gui_executor.utypes import TypeObject, UQWidget
+from gui_executor.utypes import Callback, TypeObject, UQWidget
 
 from tvac.strain_gauge import (
     get_cached_sg_channel_settings,
@@ -16,6 +16,19 @@ from tvac.strain_gauge import (
     set_sg_runtime_settings,
     start_sg_logging,
     stop_sg_logging,
+)
+from tvac.tasks.tvac.strain_gauges import (
+    sg_buffer_size,
+    sg_csv_base_filename,
+    sg_csv_enabled,
+    sg_csv_max_file_size_bytes,
+    sg_csv_save_path,
+    sg_plot_enabled,
+    sg_plot_interval_ms,
+    sg_plot_show_stats,
+    sg_plot_window_seconds,
+    sg_resync_interval_s,
+    sg_scan_rate,
 )
 
 UI_MODULE_DISPLAY_NAME = "1 - Strain Gauges"
@@ -31,10 +44,6 @@ def _set_combo_value(combo: QComboBox, value) -> None:
     idx = combo.findText(str(value))
     if idx >= 0:
         combo.setCurrentIndex(idx)
-
-
-def _set_line_text(field: QLineEdit, value) -> None:
-    field.setText(str(value))
 
 
 def _fallback_ain_channel(name: str) -> int:
@@ -132,150 +141,6 @@ class SGChannelConfigWidget(UQWidget):
         return config
 
 
-class SGStreamConfig(TypeObject):
-    def __init__(self, name: str = "Stream settings"):
-        super().__init__(name=name)
-
-    def get_widget(self):
-        return SGStreamConfigWidget()
-
-
-class SGStreamConfigWidget(UQWidget):
-    def __init__(self):
-        super().__init__()
-
-        self.scan_rate = QLineEdit()
-        self.resync_interval_s = QLineEdit()
-        self.buffer_size = QLineEdit()
-
-        layout = QHBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.scan_rate)
-        layout.addWidget(self.resync_interval_s)
-        layout.addWidget(self.buffer_size)
-        self.setLayout(layout)
-
-        self._refresh_from_effective_settings()
-
-    def _refresh_from_effective_settings(self):
-        stream = get_sg_effective_settings()["stream"]
-        _set_line_text(self.scan_rate, stream["scan_rate"])
-        _set_line_text(self.resync_interval_s, stream["resync_interval_s"])
-        _set_line_text(self.buffer_size, stream["buffer_size"])
-
-    def get_value(self):
-        config = {
-            "scan_rate": float(self.scan_rate.text()),
-            "resync_interval_s": int(self.resync_interval_s.text()),
-            "buffer_size": int(self.buffer_size.text()),
-        }
-        set_sg_runtime_settings(**config)
-        self._refresh_from_effective_settings()
-        return config
-
-
-class SGCSVConfig(TypeObject):
-    def __init__(self, name: str = "CSV settings"):
-        super().__init__(name=name)
-
-    def get_widget(self):
-        return SGCSVConfigWidget()
-
-
-class SGCSVConfigWidget(UQWidget):
-    def __init__(self):
-        super().__init__()
-
-        self.enabled_cb = QCheckBox("enabled")
-        self.save_path = QLineEdit()
-        self.base_filename = QLineEdit()
-        self.max_file_size_bytes = QLineEdit()
-
-        layout = QHBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.enabled_cb)
-        layout.addWidget(self.save_path)
-        layout.addWidget(self.base_filename)
-        layout.addWidget(self.max_file_size_bytes)
-        self.setLayout(layout)
-
-        self._refresh_from_effective_settings()
-
-    def _refresh_from_effective_settings(self):
-        csv_cfg = get_sg_effective_settings()["csv"]
-        self.enabled_cb.setChecked(bool(csv_cfg["enabled"]))
-        _set_line_text(self.save_path, csv_cfg["save_path"])
-        _set_line_text(self.base_filename, csv_cfg["base_filename"])
-        _set_line_text(self.max_file_size_bytes, csv_cfg["max_file_size_bytes"])
-
-    def get_value(self):
-        config = {
-            "csv_enabled": self.enabled_cb.isChecked(),
-            "csv_save_path": self.save_path.text(),
-            "csv_base_filename": self.base_filename.text(),
-            "csv_max_file_size_bytes": int(self.max_file_size_bytes.text()),
-        }
-        set_sg_runtime_settings(**config)
-        self._refresh_from_effective_settings()
-        return {
-            "enabled": bool(config["csv_enabled"]),
-            "save_path": str(config["csv_save_path"]),
-            "base_filename": str(config["csv_base_filename"]),
-            "max_file_size_bytes": int(config["csv_max_file_size_bytes"]),
-        }
-
-
-class SGPlotConfig(TypeObject):
-    def __init__(self, name: str = "Plot settings"):
-        super().__init__(name=name)
-
-    def get_widget(self):
-        return SGPlotConfigWidget()
-
-
-class SGPlotConfigWidget(UQWidget):
-    def __init__(self):
-        super().__init__()
-
-        self.enabled_cb = QCheckBox("enabled")
-        self.window_seconds = QLineEdit()
-        self.interval_ms = QLineEdit()
-        self.show_stats_cb = QCheckBox("show_stats")
-
-        layout = QHBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.enabled_cb)
-        layout.addWidget(self.window_seconds)
-        layout.addWidget(self.interval_ms)
-        layout.addWidget(self.show_stats_cb)
-        self.setLayout(layout)
-
-        self._refresh_from_effective_settings()
-
-    def _refresh_from_effective_settings(self):
-        plot = get_sg_effective_settings()["plot"]
-        self.enabled_cb.setChecked(bool(plot["enabled"]))
-        _set_line_text(self.window_seconds, plot["window_seconds"])
-        _set_line_text(self.interval_ms, plot["interval_ms"])
-        self.show_stats_cb.setChecked(bool(plot["show_stats"]))
-
-    def get_value(self):
-        config = {
-            "plot_enabled": self.enabled_cb.isChecked(),
-            "plot_window_seconds": float(self.window_seconds.text()),
-            "plot_interval_ms": int(self.interval_ms.text()),
-            "plot_show_stats": self.show_stats_cb.isChecked(),
-        }
-        set_sg_runtime_settings(**config)
-        self._refresh_from_effective_settings()
-        return {
-            "enabled": bool(config["plot_enabled"]),
-            "window_seconds": float(config["plot_window_seconds"]),
-            "interval_ms": int(config["plot_interval_ms"]),
-            "show_stats": bool(config["plot_show_stats"]),
-        }
-
-
 @exec_ui(display_name="Query Settings", use_kernel=True)
 def settings() -> None:
     """Print effective SG settings (Setup + runtime overrides)."""
@@ -312,15 +177,16 @@ def configure_sg_channel(
 
 @exec_ui(display_name="Configure stream", use_kernel=True)
 def configure_stream(
-    config: SGStreamConfig(name="scan_rate / resync_interval_s / buffer_size") = None,
+    scan_rate: Callback(sg_scan_rate, name="Scan rate [Hz]") = None,
+    resync_interval_s: Callback(sg_resync_interval_s, name="Resync interval [s]") = None,
+    buffer_size: Callback(sg_buffer_size, name="Buffer size") = None,
 ) -> None:
     """Set runtime stream settings (applied on next Start logging)."""
     try:
-        cfg = config or {}
         set_sg_runtime_settings(
-            scan_rate=float(cfg.get("scan_rate", 496.0)),
-            resync_interval_s=int(cfg.get("resync_interval_s", 60)),
-            buffer_size=int(cfg.get("buffer_size", 32768)),
+            scan_rate=float(scan_rate),
+            resync_interval_s=int(resync_interval_s),
+            buffer_size=int(buffer_size),
         )
         print("Stream runtime settings updated.")
         print(get_sg_settings())
@@ -330,18 +196,18 @@ def configure_stream(
 
 @exec_ui(display_name="Configure CSV", use_kernel=True)
 def configure_csv(
-    config: SGCSVConfig(
-        name="enabled / save_path / base_filename / max_file_size_bytes"
-    ) = None,
+    enabled: Callback(sg_csv_enabled, name="Enable CSV logging") = None,
+    save_path: Callback(sg_csv_save_path, name="Save path") = None,
+    base_filename: Callback(sg_csv_base_filename, name="Base filename") = None,
+    max_file_size_bytes: Callback(sg_csv_max_file_size_bytes, name="Max file size [bytes]") = None,
 ) -> None:
     """Set runtime CSV settings (applied on next Start logging)."""
     try:
-        cfg = config or {}
         set_sg_runtime_settings(
-            csv_enabled=bool(cfg.get("enabled", True)),
-            csv_save_path=str(cfg.get("save_path", ".")),
-            csv_base_filename=str(cfg.get("base_filename", "labjack_sg_data")),
-            csv_max_file_size_bytes=int(cfg.get("max_file_size_bytes", 5_120_000)),
+            csv_enabled=bool(enabled),
+            csv_save_path=str(save_path),
+            csv_base_filename=str(base_filename),
+            csv_max_file_size_bytes=int(max_file_size_bytes),
         )
         print("CSV runtime settings updated.")
         print(get_sg_settings())
@@ -365,18 +231,18 @@ def config_metrics(enabled: bool = True) -> None:
 
 @exec_ui(display_name="Configure plot", use_kernel=True)
 def configure_plot(
-    config: SGPlotConfig(
-        name="enabled / window_seconds / interval_ms / show_stats"
-    ) = None,
+    enabled: Callback(sg_plot_enabled, name="Enable plot") = None,
+    window_seconds: Callback(sg_plot_window_seconds, name="Window [s]") = None,
+    interval_ms: Callback(sg_plot_interval_ms, name="Update interval [ms]") = None,
+    show_stats: Callback(sg_plot_show_stats, name="Show stats") = None,
 ) -> None:
     """Set runtime plot settings (applied on next Start logging)."""
     try:
-        cfg = config or {}
         set_sg_runtime_settings(
-            plot_enabled=bool(cfg.get("enabled", True)),
-            plot_window_seconds=float(cfg.get("window_seconds", 5.0)),
-            plot_interval_ms=int(cfg.get("interval_ms", 500)),
-            plot_show_stats=bool(cfg.get("show_stats", True)),
+            plot_enabled=bool(enabled),
+            plot_window_seconds=float(window_seconds),
+            plot_interval_ms=int(interval_ms),
+            plot_show_stats=bool(show_stats),
         )
         print("Plot runtime settings updated.")
         print(get_sg_settings())


### PR DESCRIPTION
As noted by Sara, I didn't need to use custom widgets in the strain gauge UI. So, this PR cleans it up a bit and uses the Callback function to generate the widgets, while retaining the default values (like we did for the sine sweep parameters).