### PR TITLE
Change wave_generators.calibration references with wave_generators.piezo_tests

### DIFF
--- a/src/tvac/tasks/tvac/piezos/__init__.py
+++ b/src/tvac/tasks/tvac/piezos/__init__.py
@@ -10,7 +10,7 @@ def profiles() -> List[str]:
 
     setup = load_setup()
 
-    return list(setup.gse.wave_generators.calibration.profiles.keys())
+    return list(setup.gse.wave_generators.piezo_tests.profiles.keys())
 
 
 def piezos() -> List[str]:

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -218,12 +218,12 @@ def extract_awg_config_from_setup(profile: str, setup: Setup = None):
     """
 
     setup = setup or load_setup()
-    calibration = setup.gse.wave_generators.calibration
+    piezo_tests = setup.gse.wave_generators.piezo_tests
 
     # noinspection PyUnresolvedReferences
-    output_load = calibration.output_load
+    output_load = piezo_tests.output_load
     # noinspection PyUnresolvedReferences
-    profile = calibration.profiles[profile]
+    profile = piezo_tests.profiles[profile]
     frequency = profile["frequency"]
 
     v1_config = ArbConfig(


### PR DESCRIPTION
In setup 6, we renamed `wave_generators.calibration` to `wave_generators.piezo_tests`. Some parts of the code were still using the legacy naming though.