### PR TITLE
Corrected frequency in the loaded AWG profile

### DIFF
--- a/src/tvac/directives.py
+++ b/src/tvac/directives.py
@@ -10,6 +10,10 @@ def load_piezo_voltage_profile(
 ) -> dict:
     """Loads the voltage profiles for the piezo actuators from the given file.
 
+    Note that the frequency in the MatLab file refers to how fast we go from one point to the next one in the time
+    series, rather than the rate at which to repeat the voltage profile as a whole.  The latter is the frequency that
+    we use in the returned dictionary.
+
     Args:
         resource_name (str): Path to the resource, either relative or absolute.  If it starts with "piezo//", this
                              prefix will be stripped off.
@@ -40,8 +44,12 @@ def load_piezo_voltage_profile(
 
     signal = piezo_setup[signal_key]
 
+    intra_point_frequency = np.asarray(signal["f_Hz"][0, 0]).item() # [Hz]
+    num_points = len(np.ravel(signal["t_vec_s"][0, 0]))
+
+
     return {
-        "frequency": np.asarray(signal["f_Hz"][0, 0]).item(),
+        "frequency": intra_point_frequency / num_points,
         "time": np.ravel(signal["t_vec_s"][0, 0]),
         "V1_V": np.ravel(signal["V1_V"][0, 0]),
         "V2_V": np.ravel(signal["V2_V"][0, 0]),


### PR DESCRIPTION
The frequency in the MatLab file refers to how fast we go from one point to the next one in the time series of the voltage profiles, rather than the rate at which to repeat the voltage profile as a whole.  The latter is the frequency that we use in the returned dictionary.