### PR TITLE
Propagate metrics in batch without conversion

### DIFF
--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -545,16 +545,15 @@ def _on_stream_data(
                 _rotate_csv(channel_names)
 
     if metrics_enabled:
-        points = [
-            {
-                "measurement": ORIGIN.lower(),
-                "time": ts,
-                "fields": dict(zip(channel_names, row)),
-            }
-            for ts, row in zip(timestamps, readings)
-        ]
+        df = pd.DataFrame(readings, columns=channel_names)
+        df["time"] = timestamps
+        df.set_index("time", inplace=True)
+
         try:
-            metrics_client.write(points)
+            metrics_client.write(
+                record=df,
+                data_frame_measurement_name=ORIGIN.lower(),
+            )
         except Exception as exc:
             global _metrics_write_failed
             if not _metrics_write_failed:

--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -550,9 +550,8 @@ def _on_stream_data(
         df.set_index("time", inplace=True)
 
         try:
-            metrics_client.write(
-                df,
-                measurement_name=ORIGIN.lower(),
+            metrics_client.write_dataframe(
+                df, measurement=ORIGIN.lower(), timestamp_column="time"
             )
         except Exception as exc:
             global _metrics_write_failed

--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -551,7 +551,7 @@ def _on_stream_data(
 
         try:
             metrics_client.write(
-                record=df,
+                df,
                 data_frame_measurement_name=ORIGIN.lower(),
             )
         except Exception as exc:

--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -552,7 +552,7 @@ def _on_stream_data(
         try:
             metrics_client.write(
                 df,
-                data_frame_measurement_name=ORIGIN.lower(),
+                measurement_name=ORIGIN.lower(),
             )
         except Exception as exc:
             global _metrics_write_failed

--- a/src/tvac/tasks/tvac/piezos/characterization.py
+++ b/src/tvac/tasks/tvac/piezos/characterization.py
@@ -53,18 +53,17 @@ def start_piezo_characterization(
         fixed_voltage (float): Fixed voltage for the other piezo actuators.
     """
 
-    try:
-        start_observation(f"Characterisation of piezo actuator {piezo}")
+    start_observation(f"Characterisation of piezo actuator {piezo}")
 
-        characterize_piezo(
-            piezo=piezo,
-            amplitude=amplitude,
-            dc_offset=dc_offset,
-            start_frequency=start_frequency,
-            stop_frequency=stop_frequency,
-            sweep_time=sweep_time,
-            fixed_voltage=fixed_voltage,
-            setup=load_setup(),
-        )
-    finally:
-        end_observation()
+    characterize_piezo(
+        piezo=piezo,
+        amplitude=amplitude,
+        dc_offset=dc_offset,
+        start_frequency=start_frequency,
+        stop_frequency=stop_frequency,
+        sweep_time=sweep_time,
+        fixed_voltage=fixed_voltage,
+        setup=load_setup(),
+    )
+
+    end_observation()

--- a/src/tvac/tasks/tvac/piezos/profiles.py
+++ b/src/tvac/tasks/tvac/piezos/profiles.py
@@ -23,19 +23,16 @@ def load_profile(
         profile: Voltage profile.
     """
 
+    start_observation("Configure + switch on wave generators, using profile {profile}")
+
     try:
-        start_observation(
-            "Configure + switch on wave generators, using profile {profile}"
+        load_voltage_profile(profile=profile, setup=load_setup())
+    except Exception as e:
+        print(
+            f"Failed to configure + switch on wave generators, using profile {profile}: {e}"
         )
 
-        try:
-            load_voltage_profile(profile=profile, setup=load_setup())
-        except Exception as e:
-            print(
-                f"Failed to configure + switch on wave generators, using profile {profile}: {e}"
-            )
-    finally:
-        end_observation()
+    end_observation()
 
 
 @exec_ui(display_name="Plot profile", use_kernel=True)

--- a/src/tvac/tasks/tvac/piezos/switch_off.py
+++ b/src/tvac/tasks/tvac/piezos/switch_off.py
@@ -15,12 +15,11 @@ ICON_PATH = HERE / "icons/"
 def switch_off_piezos() -> None:
     """Switches off the Wave Generators."""
 
-    try:
-        start_observation("Switch off wave generation for piezo actuators")
+    start_observation("Switch off wave generation for piezo actuators")
 
-        try:
-            switch_off_awg(setup=load_setup())
-        except Exception as e:
-            print(f"Failed to switch off wave generation for piezo actuators: {e}")
-    finally:
-        end_observation()
+    try:
+        switch_off_awg(setup=load_setup())
+    except Exception as e:
+        print(f"Failed to switch off wave generation for piezo actuators: {e}")
+
+    end_observation()

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -42,7 +42,7 @@ class ArbConfig:
         self._amplitude = float(np.max(signal) - np.min(signal))  # Amplitude [V]
         # noinspection PyUnresolvedReferences
         self._dc_offset = float(
-            (np.max(signal) - np.min(signal)) / 2.0
+            (np.max(signal) + np.min(signal)) / 2.0
         )  # DC offset [V]
         self._output_load = output_load  # Output load [Ω]
 


### PR DESCRIPTION
Attempt to fix #57.

So far, we created a list of dictionaries which we sent to InfluxDB, where each dictionary represented one item in that data batch.  However, it looks like this conversion took too much time, therefore blocking the logging of the strain gauges.  In this PR, we organise the incoming data batch into a pandas DataFrame, which we send to InfluxDB.