### PR TITLE
Use MetricsHubSender for LabJack SG metrics

### DIFF
--- a/src/tvac/labjack_t7.py
+++ b/src/tvac/labjack_t7.py
@@ -14,11 +14,8 @@ session lifecycle and output handling.
 """
 
 import datetime
-import os
 import threading
 
-from egse.log import egse_logger
-from egse.metrics import get_metrics_repo
 from egse.setup import Setup
 from labjack import ljm
 from labjack.ljm.ljm import LJMError
@@ -109,28 +106,6 @@ class LabJackT7Logger:
 
         self._connect()
         self._configure()
-
-        # Connection to InfluxDB
-
-        token = os.getenv("INFLUXDB3_AUTH_TOKEN")
-        database_name = os.getenv("INFLUXDB3_DATABASE_NAME")
-
-        if database_name and token:
-            self.metrics_client = get_metrics_repo(
-                "influxdb",
-                {
-                    "host": "http://localhost:8181",
-                    "database": database_name,
-                    "token": token,
-                },
-            )
-            self.metrics_client.connect()
-        else:
-            self.metrics_client = None
-            egse_logger.warning(
-                "INFLUXDB3_AUTH_TOKEN and/or PROJECT environment variable is not set. "
-                "Metrics will not be propagated to InfluxDB."
-            )
 
     @classmethod
     def from_setup(cls, setup: Setup = None):
@@ -299,7 +274,6 @@ class LabJackT7Logger:
 
         if self._callback:
             self._callback(
-                metrics_client=self.metrics_client,
                 timestamps=timestamps,
                 readings=readings,
                 channel_names=self.channel_names,
@@ -317,8 +291,8 @@ class LabJackT7Logger:
                 timestamps    : list[datetime.datetime]
                 readings      : list[list[float]]
                 channel_names : list[str]
-                device_backlog: int
-                ljm_backlog   : int
+                device_backlog : int
+                ljm_backlog    : int
 
         Notes
         -----

--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -489,7 +489,6 @@ def _rotate_csv(headers):
 
 def _on_stream_data(
     *,
-    metrics_client=None,
     timestamps,
     readings,
     channel_names,


### PR DESCRIPTION
This hopefully fixes #57 (still untested). The likely cause for #57 is that in the LabJack's data stream callback function, we were writing the metrics to influxdb. This can be a slow process, which blocks the data flow and in the end causes the data transfer to freeze. This PR moves this heavyweight metrics writing to the `MetricsHubSender`. The data stream callback sends the new data points to `MetricsHubSender`, which Rik assured me is lightweight 🙂 , thus not blocking this function anymore.