### PR TITLE
Correct awg device and channel zipping & Reset awg after both channels are configured

### DIFF
--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -184,9 +184,8 @@ def load_voltage_profile(profile: str, setup: Setup = None) -> None:
             awg: Tgf4000Interface = awg_info.device
             awg.reconnect()  # Mitigate possible connection issues (#54)
 
-            awg_list.append(awg)
-
             for piezo_name, channel in awg_info.piezo_channels.items():
+                awg_list.append(awg)
                 channel_list.append(channel)
 
     # Extract the voltage profiles for the piezo actuators


### PR DESCRIPTION
There was an issue with the awg device and channel zipping, causing wrong channel configurations + when switching off the devices, the awg should be reset after the two channels have been turned off.