### PR TITLE
Improvements to sine sweep task

### DIFF
--- a/src/tvac/tasks/tvac/piezos/test.py
+++ b/src/tvac/tasks/tvac/piezos/test.py
@@ -94,7 +94,7 @@ def sine_sweep(
 
     # Let the sine sweep go on for the requested duration
 
-    time.sleep(sweep_time)
+    time.sleep(float(sweep_time))
 
     # Stop the sine sweep
 

--- a/src/tvac/tasks/tvac/piezos/test.py
+++ b/src/tvac/tasks/tvac/piezos/test.py
@@ -75,6 +75,10 @@ def sine_sweep(
 
     setup = load_setup()
 
+    # Interrupt ongoing logging
+
+    disable_sg_logging()
+
     # Configure + enable the logging of the requested strain gauge
 
     enable_sg_logging(sg_name=strain_gauge, scan_rate=scan_rate, setup=setup)

--- a/src/tvac/tasks/tvac/strain_gauges/strain_gauges.py
+++ b/src/tvac/tasks/tvac/strain_gauges/strain_gauges.py
@@ -144,7 +144,7 @@ class SGChannelConfigWidget(UQWidget):
         return config
 
 
-@exec_ui(display_name="Query Settings", use_kernel=True)
+@exec_ui(display_name="Query Settings", use_kernel=True, immediate_run=True)
 def settings() -> None:
     """Print effective SG settings (Setup + runtime overrides)."""
     print(get_sg_settings())
@@ -299,7 +299,7 @@ def stop_logging() -> None:
         print(f"Failed to stop strain-gauge logging: {e}")
 
 
-@exec_ui(display_name="Status", use_kernel=True)
+@exec_ui(display_name="Status", use_kernel=True, immediate_run=True)
 def status() -> None:
     """Print the current strain-gauge logging status."""
     print(get_sg_status())


### PR DESCRIPTION
- Cast wait time to float;
- Disable ongoing logging at the start of the observation.

Additionally:
Make sure that the status tasks for the strain gauges are run immediately.