### PR TITLE
Sine sweep: incl. LabJack configuration

### DIFF
--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -864,7 +864,6 @@ def disable_sg_logging(setup: Setup = None) -> None:
     """
 
     setup = setup or load_setup()
-    sg_setup = setup.gse.labjack_t7.channels
 
     # Stop logging (for all strain gauges)
 
@@ -875,14 +874,19 @@ def disable_sg_logging(setup: Setup = None) -> None:
     reset_sg_runtime_settings()
     reset_sg(setup=setup)
 
-    # Disable all LabJack channels
+@building_block
+def disable_sg_channels(setup: Setup = None) -> None:
+    """Disables all LabJack channels."""
+
+    setup = setup or load_setup()
+    sg_setup = setup.gse.labjack_t7.channels
 
     for sg_name, sg_info in sg_setup.items():
         set_sg_channel_runtime_settings(
             sg_name=sg_name,
             enabled=False,
             ain_channel=sg_info.ain_channel,
-            setup=setup,
+            setup=setup
         )
 
 

--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -859,8 +859,7 @@ def disable_sg_logging(setup: Setup = None) -> None:
     The following steps are performed:
 
         - Stop the logging of the strain gauges,
-        - Revert the configuration of the LabJack to the values in the setup,
-        - Disable all LabJack channels.
+        - Revert the configuration of the LabJack to the values in the setup.
     """
 
     setup = setup or load_setup()

--- a/src/tvac/tasks/tvac/piezos/profiles.py
+++ b/src/tvac/tasks/tvac/piezos/profiles.py
@@ -24,7 +24,7 @@ def load_profile(
         profile: Voltage profile.
     """
 
-    start_observation(f"Configure + switch on wave generators, using profile {profile}")
+    start_observation(f"Voltage profile {profile}")
 
     try:
         load_voltage_profile(profile=profile, setup=load_setup())

--- a/src/tvac/tasks/tvac/piezos/switch_off.py
+++ b/src/tvac/tasks/tvac/piezos/switch_off.py
@@ -4,22 +4,22 @@ from egse.observation import start_observation, end_observation
 from egse.setup import load_setup
 from gui_executor.exec import exec_ui
 
-from tvac.wave_generation import switch_off_awg
+from tvac import wave_generation
 
-UI_MODULE_DISPLAY_NAME = "3 - Switch-off"
+UI_MODULE_DISPLAY_NAME = "3 - Stop wave generation + reset"
 HERE = Path(__file__).parent.parent.resolve()
 ICON_PATH = HERE / "icons/"
 
 
-@exec_ui(display_name="Switch-off", use_kernel=True)
-def switch_off_piezos() -> None:
-    """Switches off the Wave Generators."""
+@exec_ui(display_name="Stop wave generation + reset", use_kernel=True)
+def stop_wave_generation_and_reset() -> None:
+    """Stops the wave generation and resets the wave generators."""
 
-    start_observation("Switch off wave generation for piezo actuators")
+    start_observation("Stop wave generation + reset wave generators")
 
     try:
-        switch_off_awg(setup=load_setup())
+        wave_generation.stop_wave_generation_and_reset(setup=load_setup())
     except Exception as e:
-        print(f"Failed to switch off wave generation for piezo actuators: {e}")
+        print(f"Failed to stop wave generation and reset wave generators: {e}")
 
     end_observation()

--- a/src/tvac/tasks/tvac/piezos/test.py
+++ b/src/tvac/tasks/tvac/piezos/test.py
@@ -100,9 +100,23 @@ def ramp(
     period: float = 10,
     piezo_list: ListList([str], ["V1_V"]) = None,
 ) -> None:
-    """Switches off the Wave Generators."""
+    """Ramps the voltage up and down for one piezo actuator after the other.
 
-    start_observation("Ramp for piezo actuators")
+    Within the context of an observation, we perform the following steps:
+
+        - Ramp the voltage up and down for one piezo after the other.  After that, the wave generation stops, but we
+          still have to reset the settings of the wave generators.
+        - Stop the wave generation and reset.
+
+    Args:
+        amplitude (float): Amplitude of the ramp [Vpp].
+        period (float): Period of the ramp [s].
+        piezo_list (list[str]): List of piezo actuator names.
+    """
+
+    start_observation(
+        f"Subsequent voltage ramps (up and down) for piezo actuators {piezo_list}"
+    )
 
     try:
         wave_generation.ramp(
@@ -112,7 +126,9 @@ def ramp(
             setup=load_setup(),
         )
     except Exception as e:
-        print(f"Failed to run a ramp for piezo actuators: {e}")
+        print(
+            f"Failed to ramp voltages up and down for piezo actuators {piezo_list}: {e}"
+        )
 
     end_observation()
 

--- a/src/tvac/tasks/tvac/piezos/test.py
+++ b/src/tvac/tasks/tvac/piezos/test.py
@@ -1,4 +1,3 @@
-import time
 from egse.observation import start_observation, end_observation
 from egse.setup import load_setup
 from gui_executor.exec import exec_ui
@@ -6,7 +5,6 @@ from gui_executor.utypes import Callback, ListList
 from itertools import chain
 
 from tvac import wave_generation
-from tvac.strain_gauge import enable_sg_logging, disable_sg_logging
 from tvac.tasks.tvac.piezos import piezos, sine_sweep_sg_scan_rate
 from tvac.tasks.tvac.piezos import (
     sine_sweep_amplitude,
@@ -46,7 +44,7 @@ def sine_sweep(
         sine_sweep_sg_scan_rate, name="Scan rate for strain gauge [Hz]"
     ) = None,
 ):
-    """Performs a single sine sweep of the given piezo actuator, while keeping the others as a fixed voltage.
+    """Performs a single sine sweep of the given piezo actuator, while keeping the others at a fixed voltage.
 
     Within the context of an observation, we perform the following steps:
 
@@ -56,13 +54,13 @@ def sine_sweep(
         - For the given piezo actuator, we configure (and switch on) a frequency sweep.  For the other piezo actuators,
           we configure a constant voltage.
         - Sleep for the requested duration of the sine sweep (we should only cover a single sine sweep).
-        - Stop the wave generation.
+        - Stop the wave generation and reset.
         - Stop the logging of the requested strain gauge (disable + reset its parameters).
 
     Args:
         piezo: Name of the piezo actuator for which to configure a frequency sweep.
-        amplitude (str): Amplitude for the frequency sweep [Vpp].
-        dc_offset (str): DC offset for the frequency sweep [Vdc].
+        amplitude (float): Amplitude for the frequency sweep [Vpp].
+        dc_offset (float): DC offset for the frequency sweep [Vdc].
         start_frequency (float): Start frequency for the frequency sweep [Hz].
         stop_frequency (float): Stop frequency for the frequency sweep [Hz].
         sweep_time (float): Frequency sweep time [s].
@@ -71,42 +69,25 @@ def sine_sweep(
         scan_rate (float): Scan rate for the monitored strain gauge [Hz].
     """
 
-    start_observation(f"Sine sweep for piezo actuator {piezo}")
-
-    setup = load_setup()
-
-    # Interrupt ongoing logging
-
-    disable_sg_logging(setup=setup)
-
-    # Configure + enable the logging of the requested strain gauge
-
-    enable_sg_logging(sg_name=strain_gauge, scan_rate=scan_rate, setup=setup)
-
-    # Configure and initiate the sine sweep
-
-    wave_generation.sine_sweep(
-        piezo=piezo,
-        amplitude=amplitude,
-        dc_offset=dc_offset,
-        start_frequency=start_frequency,
-        stop_frequency=stop_frequency,
-        sweep_time=sweep_time,
-        fixed_voltage=fixed_voltage,
-        setup=setup,
+    start_observation(
+        f"Sine sweep for piezo actuator {piezo}, while logging strain gauge {strain_gauge}"
     )
 
-    # Let the sine sweep go on for the requested duration
-
-    time.sleep(float(sweep_time))
-
-    # Stop the sine sweep
-
-    wave_generation.switch_off_awg(setup=setup)
-
-    # Disable the logging of the strain gauges
-
-    disable_sg_logging(setup=setup)
+    try:
+        wave_generation.sine_sweep(
+            piezo=piezo,
+            amplitude=float(amplitude),
+            dc_offset=float(dc_offset),
+            start_frequency=float(start_frequency),
+            stop_frequency=float(stop_frequency),
+            sweep_time=float(sweep_time),
+            fixed_voltage=float(fixed_voltage),
+            strain_gauge=strain_gauge,
+            scan_rate=float(scan_rate),
+            setup=load_setup(),
+        )
+    except Exception as e:
+        print(f"Failed to execute sine sweep for piezo actuator {piezo}: {e}")
 
     end_observation()
 

--- a/src/tvac/tasks/tvac/piezos/trigger.py
+++ b/src/tvac/tasks/tvac/piezos/trigger.py
@@ -4,7 +4,7 @@ from gui_executor.exec import exec_ui
 
 from tvac.wave_generation import check_trigger
 
-UI_MODULE_DISPLAY_NAME = "5 - External trigger"
+UI_MODULE_DISPLAY_NAME = "4 - External trigger"
 HERE = Path(__file__).parent.parent.resolve()
 ICON_PATH = HERE / "icons/"
 

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -474,12 +474,43 @@ def ramp(
 ) -> None:
     """Ramps the voltage up and down for one piezo actuator after the other.
 
+    Within the context of an observation, we perform the following steps:
+
+        - Ramp the voltage up and down for one piezo after the other.  After that, the wave generation stops, but we
+          still have to reset the settings of the wave generators.
+        - Stop the wave generation and reset.
+
     Args:
         amplitude (float): Amplitude of the ramp [Vpp].
         period (float): Period of the ramp [s].
         piezo_list (list[str]): List of piezo actuator names.
-        setup (Setup): Setup from which to extract the information from the piezo actuators and corresponding Wave
-                       Generators.
+    """
+
+    setup = setup or load_setup()
+
+    # Configure and initiate the voltage ramp (the wave generation stops automatically, but you will still have to
+    # reset the wave generators)
+
+    start_ramp(amplitude=amplitude, period=period, piezo_list=piezo_list, setup=setup)
+
+    # Stop the wave generation + reset the wave generators
+
+    stop_wave_generation_and_reset(setup=setup)
+
+
+@building_block
+def start_ramp(
+    amplitude: float, period: float, piezo_list: list[str], setup: Setup = None
+) -> None:
+    """Ramps the voltage up and down for one piezo actuator after the other.
+
+    After that, the wave generation stops, but we still have to reset the settings of the wave generators.
+
+    Args:
+        amplitude (float): Amplitude of the ramp [Vpp].
+        period (float): Period of the ramp [s].
+        piezo_list (list[str]): List of piezo actuator names.
+        setup (Setup): Setup.
     """
 
     setup = setup or load_setup()

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -577,10 +577,15 @@ def check_trigger() -> None:
     """
 
     if not TRIGGER_SETTINGS:
-        raise AttributeError("No settings for for external trigger")
+        print("No settings found for the external trigger.  Please, check your local settings.")
+        return
 
-    hostname = TRIGGER_SETTINGS["HOSTNAME"]
-    gpio = TRIGGER_SETTINGS["GPIO"]  # BCM numbering
+    if "HOSTNAME" not in TRIGGER_SETTINGS or "GPIO" not in TRIGGER_SETTINGS:
+        print("Both the HOSTNAME and GPIO for the external trigger should be present in the settings file.")
+        return
+
+    hostname: str = TRIGGER_SETTINGS["HOSTNAME"]
+    gpio: int = TRIGGER_SETTINGS["GPIO"]  # BCM numbering
 
     s = socket.socket()
     try:

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -18,6 +18,8 @@ from egse.observation import building_block
 from egse.settings import Settings
 from egse.setup import load_setup, Setup
 
+from tvac.strain_gauge import disable_sg_logging, enable_sg_logging, disable_sg_channels
+
 TRIGGER_SETTINGS = Settings.load("Aim-TTi TGF4000").get("TRIGGER")
 
 
@@ -309,6 +311,84 @@ def extract_awg_config_from_setup(profile: str, setup: Setup = None):
 @building_block
 def sine_sweep(
     piezo: str,
+    amplitude: float = 0.2,
+    dc_offset: float = 0.15,
+    start_frequency: float = 1.0,
+    stop_frequency: float = 1500.0,
+    sweep_time: float = 40.0,
+    fixed_voltage: float = 0.15,
+    strain_gauge: str = None,
+    scan_rate: float = 7500.0,
+    setup: Setup = None,
+):
+    """Performs a single sine sweep of the given piezo actuator, while keeping the others as a fixed voltage.
+
+    Within the context of an observation, we perform the following steps:
+
+        - Interrupt all logging from the LabJack, to ensure a clean logging of the requested strain gauge.
+        - Configure + start logging of the requested strain gauge at the requested scan rate (all other configuration
+          parameters are taken from the setup).
+        - For the given piezo actuator, we configure (and switch on) a frequency sweep.  For the other piezo actuators,
+          we configure a constant voltage.
+        - Sleep for the requested duration of the sine sweep (we should only cover a single sine sweep).
+        - Stop the wave generation.
+        - Stop the logging of the requested strain gauge (disable + reset its parameters).
+
+    Args:
+        piezo: Name of the piezo actuator for which to configure a frequency sweep.
+        amplitude (float): Amplitude for the frequency sweep [Vpp].
+        dc_offset (float): DC offset for the frequency sweep [Vdc].
+        start_frequency (float): Start frequency for the frequency sweep [Hz].
+        stop_frequency (float): Stop frequency for the frequency sweep [Hz].
+        sweep_time (float): Frequency sweep time [s].
+        fixed_voltage (float): Fixed voltage for the other piezo actuators.
+        strain_gauge (StrainGauge): Strain gauge to monitor.
+        scan_rate (float): Scan rate for the monitored strain gauge [Hz].
+        setup (Setup): Setup used for the setup phase of the wave generation.
+    """
+
+    setup = setup or load_setup()
+
+    # Interrupt ongoing logging (this incl. resetting to defaults from the setup)
+    # All channels should be disabled -> This may not be the default behaviour from the setup, so do this explicitly
+
+    disable_sg_logging(setup=setup)
+    disable_sg_channels(setup=setup)
+
+    # Configure + enable the logging of the requested strain gauge
+
+    enable_sg_logging(sg_name=strain_gauge, scan_rate=scan_rate, setup=setup)
+
+    # Configure and initiate the sine sweep (keeps on going until the wave generation is stopped explicitly)
+
+    start_sine_sweep(
+        piezo=piezo,
+        amplitude=amplitude,
+        dc_offset=dc_offset,
+        start_frequency=start_frequency,
+        stop_frequency=stop_frequency,
+        sweep_time=sweep_time,
+        fixed_voltage=fixed_voltage,
+        setup=setup,
+    )
+
+    # Let the sine sweep go on for the requested duration
+
+    time.sleep(float(sweep_time))
+
+    # Stop the wave generation + reset the wave generators
+
+    stop_wave_generation_and_reset(setup=setup)
+
+    # Disable the logging of the strain gauges
+    # We don't explicitly disable the channels but settle for the default behaviour from the setup
+
+    disable_sg_logging(setup=setup)
+
+
+@building_block
+def start_sine_sweep(
+    piezo: str,
     amplitude: float,
     dc_offset: float,
     start_frequency: float,
@@ -317,14 +397,14 @@ def sine_sweep(
     fixed_voltage: float,
     setup: Setup = None,
 ) -> None:
-    """Charactersisation of the given piezo actuator.
+    """Configures and starts sine sweeps of the given piezo actuator, while keeping the others as a fixed voltage.
 
     For the given piezo actuator, we configure (and switch on) a frequency sweep.  For the other piezo actuators, we
-    configure a constant voltage.
+    configure a constant voltage.  The sine sweeps keep on going until the wave generation is stopped explicitly.
 
     Because we could not find a way to configure a triggered sweep with an external trigger signal (coming from a
     GPIO pin of a Raspberry Pi being set high), we first enable the channels with a constant voltage and then the
-    frequency sweep.
+    sine sweep.
 
     Args:
         piezo (str): Name of the piezo actuator for which to configure a frequency sweep.
@@ -334,8 +414,7 @@ def sine_sweep(
         stop_frequency (float): Stop frequency for the frequency sweep [Hz].
         sweep_time (float): Frequency sweep time [s].
         fixed_voltage (float): Fixed voltage for the other piezo actuators.
-        setup (Setup): Setup from which to extract the information from the piezo actuators and corresponding Wave
-                       Generators.
+        setup (Setup): Setup.
     """
 
     setup = setup or load_setup()
@@ -357,7 +436,7 @@ def sine_sweep(
                 awg.set_channel(channel)
 
                 if piezo_name == piezo:
-                    sweep_awg = awg
+                    sweep_awg: Tgf4000Interface = awg
                     sweep_channel = channel
 
                     awg.set_waveform_shape(WaveformShape.SINE)

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -493,6 +493,7 @@ def ramp(
 
     start_ramp(amplitude=amplitude, period=period, piezo_list=piezo_list, setup=setup)
 
+    # Sleeping for the duration of each ramp has already been included in `start_ramp`
     # Stop the wave generation + reset the wave generators
 
     stop_wave_generation_and_reset(setup=setup)

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -449,7 +449,7 @@ def ramp(
 
 
 @building_block
-def switch_off_awg(setup: Setup = None):
+def stop_wave_generation_and_reset(setup: Setup = None):
     """Switches off the wave generators.
 
     Args:

--- a/uv.lock
+++ b/uv.lock
@@ -16,15 +16,15 @@ resolution-markers = [
 
 [[package]]
 name = "aim-tti-awg"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cgse-common" },
     { name = "cgse-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/2d/a2a92080ff7c45ad3c9bbb37e29e6e3be4ab0f33a93f517c326b093100c4/aim_tti_awg-0.21.0.tar.gz", hash = "sha256:158d464b3b5e336197dcb585fc612f2d7da46c8246ef3b2ef97aa2bf0ee15975", size = 27385, upload-time = "2026-04-02T14:05:50.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/9b/8b3cccc90ea71107b49471563e66a1b08805717ea6e1dae589cdb5b7ba74/aim_tti_awg-0.22.0.tar.gz", hash = "sha256:9cb4ef5b00e37f5a514065d1169f59a2c6cf1b8fb098bf5044316f40d9e3aefc", size = 27387, upload-time = "2026-04-09T08:19:11.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/2b/28c5ae3479f04cf90d67217138719784b0a9ae28d22b22aa236289c09b66/aim_tti_awg-0.21.0-py3-none-any.whl", hash = "sha256:fab38f16eb258be3ffce798c228417ed083d02c0f50cf324728a32716446faa3", size = 31772, upload-time = "2026-04-02T14:05:53.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/6e/e4152a06fb57260265a6a1b059c54281b429e5a4cc7dcdbfcb47ff818d79/aim_tti_awg-0.22.0-py3-none-any.whl", hash = "sha256:a1175f7ea373da97821d1964a9fa6cffb199f2b69db4458736e310bae19f0581", size = 31768, upload-time = "2026-04-09T08:19:24.72Z" },
 ]
 
 [[package]]
@@ -328,7 +328,7 @@ wheels = [
 
 [[package]]
 name = "cgse-common"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -354,14 +354,14 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/70/d7224a52bee71d4460f0296ec50c9dfb566509c8be015c23155f750f9213/cgse_common-0.21.0.tar.gz", hash = "sha256:a76e62883795f62c4c879383a7ca93e15f458bb9b2413e12ec8c1bb779b47e81", size = 122756, upload-time = "2026-04-02T14:05:51.957Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/e8/ac6bababbd7db7c792fbea4cbdb4f7a704768ad78cc757a259b9ec9d777b/cgse_common-0.22.0.tar.gz", hash = "sha256:97a2f979d8838aff1ef647771d14d50952a9741f6b831af64988ef41b9c897b8", size = 124262, upload-time = "2026-04-09T08:19:25.736Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/44/02ce9de19d9bd04622cf90ec00e52e8b10470c2896a126aef3f17b0181db/cgse_common-0.21.0-py3-none-any.whl", hash = "sha256:3a6064ac65c14c4d04e100e1de909e25e1cfe21b2769a5e414ca8f6edf38eb0f", size = 136975, upload-time = "2026-04-02T14:05:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c0/8585b1a69a043637b378bf8943eeb1f4ccaa04cbd94193b3ff789fafc0e4/cgse_common-0.22.0-py3-none-any.whl", hash = "sha256:cb3b3b9c52bdb87122339ce860c36409bfab0e689e6c9b33d1db21553b051175", size = 138649, upload-time = "2026-04-09T08:19:15.041Z" },
 ]
 
 [[package]]
 name = "cgse-core"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -372,35 +372,35 @@ dependencies = [
     { name = "pytz" },
     { name = "qtpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/89/74450447463f264627377e0f179466e8d269830c5920cc67890bbf168056/cgse_core-0.21.0.tar.gz", hash = "sha256:5af2bd015c3114117e9c0a0a934364dffa8044f1005d17e27e5939346159087b", size = 155846, upload-time = "2026-04-02T14:06:01.627Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/d5/5aabd23f0227195c88c66e8ffd66d8751ea515c84c77bece5b8f85911ac1/cgse_core-0.22.0.tar.gz", hash = "sha256:6f2424d8d54a8b4b484d3a9ff5409e9b05cab3f9f747427b3d640b8bc992bfb8", size = 158216, upload-time = "2026-04-09T08:18:59.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/2e/6fa874bc192c97be843e12a2bfefaa36213179801b69bb19562c5d83fcbc/cgse_core-0.21.0-py3-none-any.whl", hash = "sha256:eb430ec6c1872911fdb7b656cd05ec9c8b2d52aec3412834ef6c425eedb7bf9e", size = 185419, upload-time = "2026-04-02T14:05:54.799Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/42/457fe61b6190dc90cc018f7070cd98a97a780d38fa3adcc365cc3a34df99/cgse_core-0.22.0-py3-none-any.whl", hash = "sha256:baef15dbff1f61f34abb0ad7aebe23e6f0b3c85e88db990aaee768cf4f2ce57b", size = 187536, upload-time = "2026-04-09T08:19:21.968Z" },
 ]
 
 [[package]]
 name = "cgse-gui"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cgse-common" },
     { name = "pyqt5" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/6a/b8044f9337a8da7a9e3b50c8c75fe3a0d2811cd754d7e7b8dd5ed682cbc7/cgse_gui-0.21.0.tar.gz", hash = "sha256:b4073b0742def90e4551454267d87ca9ab1b87c83713af546fd74a6b12834aa7", size = 178045, upload-time = "2026-04-02T14:05:46.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/b4/7aea83148e4243548fcf80767ff00be9c33740cb3f9d95c834a57b86240f/cgse_gui-0.22.0.tar.gz", hash = "sha256:6f4eed4c00fcb19f4879b446d2365111e5c1ef25983664872900e84ab0498df2", size = 178033, upload-time = "2026-04-09T08:19:02.991Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/75/8964d5efdaecb8ab42c3742e179ef5532ffcc2e004cd1de582632608c7b1/cgse_gui-0.21.0-py3-none-any.whl", hash = "sha256:2517955ecc859e0a0a8edb180a880f7e9f3f06e4371bab92d25df45a58bb9fc4", size = 284050, upload-time = "2026-04-02T14:05:52.948Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/5f/1368ff34c18d78bc028444113a800b23525e46d21c66a60bf21a1d47e23f/cgse_gui-0.22.0-py3-none-any.whl", hash = "sha256:5b4f6d7474d4c84ce959f46294f1751cf69447a517eac94303d7486e45901290", size = 284051, upload-time = "2026-04-09T08:19:14.074Z" },
 ]
 
 [[package]]
 name = "cgse-tools"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cgse-common" },
     { name = "textual" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/8f/07fd56907beb500dd780d753c434d60d108f63f8a28f4f5d50825395529a/cgse_tools-0.21.0.tar.gz", hash = "sha256:ab21fb39af0866fe27e40e759c2aba0cafcb22c61f5ad72fb42d1202437e62b9", size = 6581, upload-time = "2026-04-02T14:05:47.094Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/10/67712e493c8429eef7512ada9ad44e009f45fe039563e03490a897a59cd9/cgse_tools-0.22.0.tar.gz", hash = "sha256:420a6895fdab0811b8a7f007d8df85ede0a0f0bdd06dd2a8b5454ca429877ffa", size = 6586, upload-time = "2026-04-09T08:19:27.462Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/3b/e612991d88dfce2f8e5ab5234003573649da2def566be76a672655458920/cgse_tools-0.21.0-py3-none-any.whl", hash = "sha256:77ac980391400176aa4c04ccf3e8c9bf13b372ad416d1fd32b43e1ea944fa44b", size = 7850, upload-time = "2026-04-02T14:05:57.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e6/3d2fa9540d7186b2ce42e92407741cc99caff9e498e8141b641cd2945933/cgse_tools-0.22.0-py3-none-any.whl", hash = "sha256:8f2ffb374caa3b1c2b19aea469ec216752ac0cff99009326f8fa255484a8162b", size = 7847, upload-time = "2026-04-09T08:19:05.188Z" },
 ]
 
 [[package]]
@@ -510,14 +510,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
 ]
 
 [[package]]
@@ -723,6 +723,7 @@ dependencies = [
     { name = "cgse-core" },
     { name = "digilent" },
     { name = "gui-executor" },
+    { name = "invoke" },
     { name = "keithley-tempcontrol" },
     { name = "kikusui-power-supply" },
     { name = "labjack-ljm" },
@@ -741,6 +742,7 @@ requires-dist = [
     { name = "cgse-core" },
     { name = "digilent" },
     { name = "gui-executor" },
+    { name = "invoke" },
     { name = "keithley-tempcontrol" },
     { name = "kikusui-power-supply" },
     { name = "labjack-ljm" },
@@ -812,15 +814,15 @@ wheels = [
 
 [[package]]
 name = "digilent"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cgse-common" },
     { name = "cgse-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/51/fec5a9bad366f5b1a7bc5a9bbc92049740a896f4fd4a487a4eeec7757306/digilent-0.21.0.tar.gz", hash = "sha256:974b3c586c8c1210749fede2042f9644a3e3340136a8ca4f12a8a7a89f1092c1", size = 26568, upload-time = "2026-04-02T14:05:58.558Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/23/2b01703c7a1d18278b7499dbfbeb44122fa6fe7e623fe1fd7b6922df87a4/digilent-0.22.0.tar.gz", hash = "sha256:a5a41d09a9e480f0211e4cf69ced09b72a2df5acf0ffa7047331a6fc4450921f", size = 26694, upload-time = "2026-04-09T08:19:08.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/db/47273a603bb7fa058bab93f0d87e57519bc1c335899168d3467457d7a5a2/digilent-0.21.0-py3-none-any.whl", hash = "sha256:64f546714dba0a4245d5c631d208e08d448247b180c2f2630e6b321caecc5f99", size = 31113, upload-time = "2026-04-02T14:05:48.116Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9e/b21527a21131aa66758200ef7a150cc2d21b21fb10323cfa39b097fe815f/digilent-0.22.0-py3-none-any.whl", hash = "sha256:e33a3ad107fdaef25953fc6779623358a5be862b5de600b6d797884a59e394e1", size = 31247, upload-time = "2026-04-09T08:19:16.981Z" },
 ]
 
 [[package]]
@@ -834,44 +836,44 @@ wheels = [
 
 [[package]]
 name = "duckdb"
-version = "1.5.1"
+version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/62/590caabec6c41003f46a244b6fd707d35ca2e552e0c70cbf454e08bf6685/duckdb-1.5.1.tar.gz", hash = "sha256:b370d1620a34a4538ef66524fcee9de8171fa263c701036a92bc0b4c1f2f9c6d", size = 17995082, upload-time = "2026-03-23T12:12:15.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/66/744b4931b799a42f8cb9bc7a6f169e7b8e51195b62b246db407fd90bf15f/duckdb-1.5.2.tar.gz", hash = "sha256:638da0d5102b6cb6f7d47f83d0600708ac1d3cb46c5e9aaabc845f9ba4d69246", size = 18017166, upload-time = "2026-04-13T11:30:09.065Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/63/d6477057ea6103f80ed9499580c8602183211689889ec50c32f25a935e3d/duckdb-1.5.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:46f92ada9023e59f27edc048167b31ac9a03911978b1296c845a34462a27f096", size = 30067487, upload-time = "2026-03-23T12:10:15.712Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/b8/22e6c605d9281df7a83653f4a60168eec0f650b23f1d4648aca940d79d00/duckdb-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:caa65e1f5bf007430bf657c37cab7ab81a4ddf8d337e3062bcc5085d17ef038b", size = 15968413, upload-time = "2026-03-23T12:10:18.978Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b1/88a457cd3105525cba0d4c155f847c5c32fa4f543d3ba4ee38b4fd75f82e/duckdb-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8c0088765747ae5d6c9f89987bb36f9fb83564f07090d721344ce8e1abedffea", size = 14222115, upload-time = "2026-03-23T12:10:21.662Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3b/800c3f1d54ae0062b3e9b0b54fc54d6c155d731311931d748fc9c5c565f9/duckdb-1.5.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e56a20ab6cdb90a95b0c99652e28de3504ce77129087319c03c9098266183ae5", size = 19244994, upload-time = "2026-03-23T12:10:24.708Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/09/4c4dd94f521d016e0fb83cca2c203d10ce1e3f8bcc679691b5271fc98b83/duckdb-1.5.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:715f05ea198d20d7f8b407b9b84e0023d17f2b9096c194cea702b7840e74f1f7", size = 21347663, upload-time = "2026-03-23T12:10:27.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/b3/eb3c70be70d0b3fa6c8051d6fa4b7fb3d5787fa77b3f50b7e38d5f7cc6fd/duckdb-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:e878ccb7d20872065e1597935fdb5e65efa43220c8edd0d9c4a1a7ff1f3eb277", size = 13067979, upload-time = "2026-03-23T12:10:30.783Z" },
-    { url = "https://files.pythonhosted.org/packages/42/3e/827ffcf58f0abc6ad6dcf826c5d24ebfc65e03ad1a20d74cad9806f91c99/duckdb-1.5.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bc7ca6a1a40e7e4c933017e6c09ef18032add793df4e42624c6c0c87e0bebdad", size = 30067835, upload-time = "2026-03-23T12:10:34.026Z" },
-    { url = "https://files.pythonhosted.org/packages/04/b5/e921ecf8a7e0cc7da2100c98bef64b3da386df9444f467d6389364851302/duckdb-1.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:446d500a2977c6ae2077f340c510a25956da5c77597175c316edfa87248ceda3", size = 15970464, upload-time = "2026-03-23T12:10:42.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/da/ed804006cd09ba303389d573c8b15d74220667cbd1fd990c26e98d0e0a5b/duckdb-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b8b0808dba0c63b7633bdaefb34e08fe0612622224f9feb0e7518904b1615101", size = 14222994, upload-time = "2026-03-23T12:10:45.162Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/43/c904d81a61306edab81a9d74bb37bbe65679639abb7030d4c4fec9ed84f7/duckdb-1.5.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:553c273a6a8f140adaa6da6a6135c7f95bdc8c2e5f95252fcdf9832d758e2141", size = 19244880, upload-time = "2026-03-23T12:10:48.529Z" },
-    { url = "https://files.pythonhosted.org/packages/50/db/358715d677bfe5e117d9e1f2d6cc2fc2b0bd621144d1f15335b8b59f95d7/duckdb-1.5.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40c5220ec93790b18ec6278da9c6ac2608d997ee6d6f7cd44c5c3992764e8e71", size = 21350874, upload-time = "2026-03-23T12:10:52.095Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/db/fd647ce46315347976f5576a279bacb8134d23b1f004bd0bcda7ce9cf429/duckdb-1.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:36e8e32621a9e2a9abe75dc15a4b54a3997f2d8b1e53ad754bae48a083c91130", size = 13068140, upload-time = "2026-03-23T12:10:55.622Z" },
-    { url = "https://files.pythonhosted.org/packages/27/95/e29d42792707619da5867ffab338d7e7b086242c7296aa9cfc6dcf52d568/duckdb-1.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:5ae7c0d744d64e2753149634787cc4ab60f05ef1e542b060eeab719f3cdb7723", size = 13908823, upload-time = "2026-03-23T12:10:58.572Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/06/be4c62f812c6e23898733073ace0482eeb18dffabe0585d63a3bf38bca1e/duckdb-1.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6f7361d66cc801d9eb4df734b139cd7b0e3c257a16f3573ebd550ddb255549e6", size = 30113703, upload-time = "2026-03-23T12:11:02.536Z" },
-    { url = "https://files.pythonhosted.org/packages/44/03/1794dcdda75ff203ab0982ff7eb5232549b58b9af66f243f1b7212d6d6be/duckdb-1.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0a6acc2040bec1f05de62a2f3f68f4c12f3ec7d6012b4317d0ab1a195af26225", size = 15991802, upload-time = "2026-03-23T12:11:06.321Z" },
-    { url = "https://files.pythonhosted.org/packages/87/03/293bccd838a293d42ea26dec7f4eb4f58b57b6c9ffcfabc6518a5f20a24a/duckdb-1.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed6d23a3f806898e69c77430ebd8da0c79c219f97b9acbc9a29a653e09740c59", size = 14246803, upload-time = "2026-03-23T12:11:09.624Z" },
-    { url = "https://files.pythonhosted.org/packages/15/2c/7b4f11879aa2924838168b4640da999dccda1b4a033d43cb998fd6dc33ea/duckdb-1.5.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6af347debc8b721aa72e48671166282da979d5e5ae52dbc660ab417282b48e23", size = 19271654, upload-time = "2026-03-23T12:11:13.354Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/d6/8f9a6b1fbcc669108ec6a4d625a70be9e480b437ed9b70cd56b78cd577a6/duckdb-1.5.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8150c569b2aa4573b51ba8475e814aa41fd53a3d510c1ffb96f1139f46faf611", size = 21386100, upload-time = "2026-03-23T12:11:16.758Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/fe/8d02c6473273468cf8d43fd5d73c677f8cdfcd036c1e884df0613f124c2b/duckdb-1.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:054ad424b051b334052afac58cb216f3b1ebb8579fc8c641e60f0182e8725ea9", size = 13083506, upload-time = "2026-03-23T12:11:19.785Z" },
-    { url = "https://files.pythonhosted.org/packages/96/0b/2be786b9c153eb263bf5d3d5f7ab621b14a715d7e70f92b24ecf8536369e/duckdb-1.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:6ba302115f63f6482c000ccfd62efdb6c41d9d182a5bcd4a90e7ab8cd13856eb", size = 13888862, upload-time = "2026-03-23T12:11:22.84Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/f2/af476945e3b97417945b0f660b5efa661863547c0ea104251bb6387342b1/duckdb-1.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:26e56b5f0c96189e3288d83cf7b476e23615987902f801e5788dee15ee9f24a9", size = 30113759, upload-time = "2026-03-23T12:11:26.5Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/9d/5a542b3933647369e601175190093597ce0ac54909aea0dd876ec51ffad4/duckdb-1.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:972d0dbf283508f9bc446ee09c3838cb7c7f114b5bdceee41753288c97fe2f7c", size = 15991463, upload-time = "2026-03-23T12:11:30.025Z" },
-    { url = "https://files.pythonhosted.org/packages/53/a5/b59cff67f5e0420b8f337ad86406801cffacae219deed83961dcceefda67/duckdb-1.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:482f8a13f2600f527e427f73c42b5aa75536f9892868068f0aaf573055a0135f", size = 14246482, upload-time = "2026-03-23T12:11:33.33Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/12/d72a82fe502aae82b97b481bf909be8e22db5a403290799ad054b4f90eb4/duckdb-1.5.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da137802688190835b4c863cafa77fd7e29dff662ee6d905a9ffc14f00299c91", size = 19270816, upload-time = "2026-03-23T12:11:36.79Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c3/ee49319b15f139e04c067378f0e763f78336fbab38ba54b0852467dd9da4/duckdb-1.5.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d4147422d91ccdc2d2abf6ed24196025e020259d1d267970ae20c13c2ce84b1", size = 21385695, upload-time = "2026-03-23T12:11:40.465Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/f5/a15498e75a27a136c791ca1889beade96d388dadf9811375db155fc96d1a/duckdb-1.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:05fc91767d0cfc4cf2fa68966ab5b479ac07561752e42dd0ae30327bd160f64a", size = 13084065, upload-time = "2026-03-23T12:11:43.763Z" },
-    { url = "https://files.pythonhosted.org/packages/93/81/b3612d2bbe237f75791095e16767c61067ea5d31c76e8591c212dac13bd0/duckdb-1.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:a28531cee2a5a42d89f9ba4da53bfeb15681f12acc0263476c8705380dadce07", size = 13892892, upload-time = "2026-03-23T12:11:47.222Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/75/e9e7893542ca738bcde2d41d459e3438950219c71c57ad28b049dc2ae616/duckdb-1.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:eba81e0b3011c1f23df7ea47ef4ffaa8239817959ae291515b6efd068bde2161", size = 30123677, upload-time = "2026-03-23T12:11:51.511Z" },
-    { url = "https://files.pythonhosted.org/packages/df/db/f7420ee7109a922124c02f377ae1c56156e9e4aa434f4726848adaef0219/duckdb-1.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:afab8b4b1f4469c3879bb049dd039f8fce402712050324e9524a43d7324c5e87", size = 15996808, upload-time = "2026-03-23T12:11:54.964Z" },
-    { url = "https://files.pythonhosted.org/packages/df/57/2c4c3de1f1110417592741863ba58b4eca2f7690a421712762ddbdcd72e6/duckdb-1.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:71dddcebbc5a70e946a06c30b59b5dd7999c9833d307168f90fb4e4b672ab63e", size = 14248990, upload-time = "2026-03-23T12:11:58.576Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/81/e173b33ffac53124a3e39e97fb60a538f26651a0df6e393eb9bf7540126c/duckdb-1.5.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac2804043bd1bc10b5da18f8f4c706877197263a510c41be9b4c0062f5783dcc", size = 19276013, upload-time = "2026-03-23T12:12:02.034Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/4c/47e838393aa90d3d78549c8c04cb09452efeb14aaae0ee24dc0bd61c3a41/duckdb-1.5.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8843bd9594e1387f1e601439e19ad73abdf57356104fd1e53a708255bb95a13d", size = 21387569, upload-time = "2026-03-23T12:12:05.693Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/9b/ce65743e0e85f5c984d2f7e8a81bc908d0bac345d6d8b6316436b29430e7/duckdb-1.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:d68c5a01a283cb13b79eafe016fe5869aa11bff8c46e7141c70aa0aac808010f", size = 13603876, upload-time = "2026-03-23T12:12:09.344Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/ac/f9e4e731635192571f86f52d86234f537c7f8ca4f6917c56b29051c077ef/duckdb-1.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:a3be2072315982e232bfe49c9d3db0a59ba67b2240a537ef42656cc772a887c7", size = 14370790, upload-time = "2026-03-23T12:12:12.497Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/03b96203d9bf4ff8637de4d42adeca5b43342a5050f656eccce1e69d6879/duckdb-1.5.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:63bf8687feefeed51adf45fa3b062ab8b1b1c350492b7518491b86bae68b1da1", size = 30017339, upload-time = "2026-04-13T11:28:36.134Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f4/2f4af0233489fc92822ff6021a2a4e05f7cd75fa1a352a163967fbeeab22/duckdb-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:84b193aca20565dedb3172de15f843c659c3a6c773bf14843a9bd781c850e7db", size = 15945057, upload-time = "2026-04-13T11:28:39.21Z" },
+    { url = "https://files.pythonhosted.org/packages/34/0a/d41ee8cdeb63cf12f2ee9e6c8e17cc8bacff6468013be703e44fd2a22efa/duckdb-1.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5596bbfc31b1b259db69c8d847b42d036ce2c4804f9ccb28f9fc46a16de7bc53", size = 14199133, upload-time = "2026-04-13T11:28:41.791Z" },
+    { url = "https://files.pythonhosted.org/packages/11/39/4da08139b109d7f84b12ecca202a5adfff5b1b20970c01bd82dc09d86a59/duckdb-1.5.2-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8dbd7e31e5dc157bfe8803fa7d2652336265c6c19926c5a4a9b40f8222868d08", size = 19285501, upload-time = "2026-04-13T11:28:44.208Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/cc/10a542561634408cbae951a836e645dda784ddc48eaa2ee72701a2992a8e/duckdb-1.5.2-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9cd5e71702d446613750405cde03f66ed268f4c321da071b0472759dad19536", size = 21392488, upload-time = "2026-04-13T11:28:46.923Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/61/e9015ee2117f86c2e8396ad66b85c8338b2ecdc9a20eb5b099a537cf3c6a/duckdb-1.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:ce17670bb392ea1b3650537db02bd720908776b5b95f6d2472d31a7de59d1dc1", size = 13096311, upload-time = "2026-04-13T11:28:49.635Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/b0/d13e7e396d86c245290b3e93f692a2d27c2fe99f857aaf9205003c00c978/duckdb-1.5.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7f69164b048e498b9e9140a24343108a5ae5f17bfb3485185f55fdf9b1aa924d", size = 30020978, upload-time = "2026-04-13T11:28:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7b/ae1ec7f516394aa55501d1949af1f731be8d9d7433f0acc3f4632a0ba484/duckdb-1.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:81fc4fbf0b5e25840b39ba2a10b78c6953c0314d5d0434191e7898f34ab1bba3", size = 15947821, upload-time = "2026-04-13T11:28:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a5/cae0105e01a85f85ead61723bb42dab14c2f8ec49f91e67a2372c02574a4/duckdb-1.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56d38b3c4e0ef2abb58898d0fd423933999ed535c45e75e9d9f72e1d5fed69b8", size = 14201656, upload-time = "2026-04-13T11:28:58.316Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/46c57e8813ac33762bddc9545610ed648751c5b6a379abf2dc6035505ce4/duckdb-1.5.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:376856066c65ccd55fcb3a380bbe33a71ce089fc4623d229ffc6e82251afdb6d", size = 19285181, upload-time = "2026-04-13T11:29:01.041Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/67694010693ec8c8c975e6991f48ef886d35ecbdaa2f287234882a403c21/duckdb-1.5.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c69907354ffee94ba8cf782daf0480dab7557f21ce27fffa6c0ea8f74ed4b8e2", size = 21394852, upload-time = "2026-04-13T11:29:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/52/9f/2b1618c5a93949a70dcf105293db7e27bb2b2cc4aeb1ff46b806f430ec81/duckdb-1.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:d9b4f5430bf4f05d4c0dc4c55c75def3a5af4be0343be20fa2bfc577343fbfc9", size = 13095526, upload-time = "2026-04-13T11:29:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/cb39e0d94a32f5333e819112fd01439a31f541f9c56a31b66f9bd209704b/duckdb-1.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:2323c1195c10fb2bb982fc0218c730b43d1b92a355d61e68e3c5f3ac9d44c34f", size = 13946215, upload-time = "2026-04-13T11:29:08.672Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/ebe66bbe78125fc610f4fd415447a65349d94245950f3b3dfb31d028af02/duckdb-1.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e6495b00cad16888384119842797c49316a96ae1cb132bb03856d980d95afee1", size = 30064950, upload-time = "2026-04-13T11:29:11.468Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d72b8856b1839d35648f38301b058f6232f4d36b463fe4dc8f4d3fdff2df1a2e", size = 15969113, upload-time = "2026-04-13T11:29:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a1de4f4d454b8c97aec546c82003fc834d3422ce4bc6a19902f3462ef293bed", size = 14224774, upload-time = "2026-04-13T11:29:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2f/a7f0de9509d1cef35608aeb382919041cdd70f58c173865c3da6a0d87979/duckdb-1.5.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce0b8141a10d37ecef729c45bc41d334854013f4389f1488bd6035c5579aaac1", size = 19313510, upload-time = "2026-04-13T11:29:19.574Z" },
+    { url = "https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99ef73a277c8921bc0a1f16dee38d924484251d9cfd20951748c20fcd5ed855", size = 21429692, upload-time = "2026-04-13T11:29:22.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/12/05b0c47d14839925c5e35b79081d918ca82e3f236bb724a6f58409dd5291/duckdb-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:8d599758b4e48bf12e18c9b960cf491d219f0c4972d19a45489c05cc5ab36f83", size = 13107594, upload-time = "2026-04-13T11:29:25.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2c/80558a82b236e044330e84a154b96aacddb343316b479f3d49be03ea11cb/duckdb-1.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:fc85a5dbcbe6eccac1113c72370d1d3aacfdd49198d63950bdf7d8638a307f00", size = 13927537, upload-time = "2026-04-13T11:29:27.842Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f2/e3d742808f138d374be4bb516fade3d1f33749b813650810ab7885cdc363/duckdb-1.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4420b3f47027a7849d0e1815532007f377fa95ee5810b47ea717d35525c12f79", size = 30064879, upload-time = "2026-04-13T11:29:30.763Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/f3dc1cf97e1267ca15e4307d456f96ce583961f0703fd75e62b2ad8d64fa/duckdb-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bb42e6ed543902e14eae647850da24103a89f0bc2587dec5601b1c1f213bd2ed", size = 15969327, upload-time = "2026-04-13T11:29:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/d5418def53ae4e05a63075705ff44ed5af5a1a5932627eb2b600c5df1c93/duckdb-1.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98c0535cd6d901f61a5ea3c2e26a1fd28482953d794deb183daf568e3aa5dda6", size = 14225107, upload-time = "2026-04-13T11:29:35.882Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a7/15aaa59dbecc35e9711980fcdbf525b32a52470b32d18ef678193a146213/duckdb-1.5.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486c862bf7f163c0110b6d85b3e5c031d224a671cca468f12ebb1d3a348f6b39", size = 19313433, upload-time = "2026-04-13T11:29:38.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/21/d903cc63a5140c822b7b62b373a87dc557e60c29b321dfb435061c5e67cf/duckdb-1.5.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70631c847ca918ee710ec874241b00cf9d2e5be90762cbb2a0389f17823c08f7", size = 21429837, upload-time = "2026-04-13T11:29:41.135Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/0a/b770d1f60c70597302130d6247f418549b7094251a02348fbaf1c7e147ae/duckdb-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:52a21823f3fbb52f0f0e5425e20b07391ad882464b955879499b5ff0b45a376b", size = 13107699, upload-time = "2026-04-13T11:29:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/e200fe431d700962d1a908d2ce89f53ccee1cc8db260174ae663ba09686b/duckdb-1.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:411ad438bd4140f189a10e7f515781335962c5d18bd07837dc6d202e3985253d", size = 13927646, upload-time = "2026-04-13T11:29:46.598Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a1/f6286c67726cc1ea60a6e3c0d9fbc66527dde24ae089a51bbe298b13ca78/duckdb-1.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6b0fe75c148000f060aa1a27b293cacc0ea08cc1cad724fbf2143d56070a3785", size = 30078598, upload-time = "2026-04-13T11:29:49.828Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/59febb02f21a4a5c6b0b0099ef7c965fdd5e61e4904cf813809bb792e35f/duckdb-1.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35579b8e3a064b5eaf15b0eafc558056a13f79a0a62e34cc4baf57119daecfec", size = 15975120, upload-time = "2026-04-13T11:29:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/09/70/ce750854d37bb5a45cccbb2c3cb04df4af56aea8fc30a2499bb643b4a9c0/duckdb-1.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea58ff5b0880593a280cf5511734b17711b32ee1f58b47d726e8600848358160", size = 14227762, upload-time = "2026-04-13T11:29:55.564Z" },
+    { url = "https://files.pythonhosted.org/packages/28/dc/ad45ac3c0b6c4687dc649e8f6cf01af1c8b0443932a39b2abb4ebcb3babd/duckdb-1.5.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef461bca07313412dc09961c4a4757a851f56b95ac01c58fac6007632b7b94f2", size = 19315668, upload-time = "2026-04-13T11:29:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
 ]
 
 [[package]]
@@ -1197,6 +1199,15 @@ wheels = [
 ]
 
 [[package]]
+name = "invoke"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419, upload-time = "2026-04-07T15:17:48.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958, upload-time = "2026-04-07T15:17:46.875Z" },
+]
+
+[[package]]
 name = "ipykernel"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1379,7 +1390,7 @@ wheels = [
 
 [[package]]
 name = "keithley-tempcontrol"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cgse-common" },
@@ -1387,22 +1398,22 @@ dependencies = [
     { name = "cgse-gui" },
     { name = "pyqt5" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/9e/81451dd7662a6868cdbd8bc7387666d33737bde2937b8f895c2f7b54d381/keithley_tempcontrol-0.21.0.tar.gz", hash = "sha256:bd38317349c3449cf135fa5a27f054745cee465946190ad4e1ec27028767d5a5", size = 25551, upload-time = "2026-04-02T14:06:02.509Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/0a/ecf0b1869d1ada02fcc862674b0ff65494435db29d6701cef68c3f16f69a/keithley_tempcontrol-0.22.0.tar.gz", hash = "sha256:403ee40667eda58a875884c4a65931ef0b0db10458d7cfc1ec140c661faada43", size = 25546, upload-time = "2026-04-09T08:19:21.326Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/7a/cea4b8980be1120b51c93dfd69cad186ed5044b583391ab971f852edb2ce/keithley_tempcontrol-0.21.0-py3-none-any.whl", hash = "sha256:e8305b188db87664471ec7783781ab8270fc79953550996e2e708c948121cdf4", size = 30781, upload-time = "2026-04-02T14:06:14.582Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e6/27e4872519b9f57c4877e43f5f3b7036dc6858ee3c2b3b13cc8a04a9ea59/keithley_tempcontrol-0.22.0-py3-none-any.whl", hash = "sha256:831d03bd6b5c6de0c0d3bf54a85613c31b78ad847598b1aefd49d3fcb29720f4", size = 30781, upload-time = "2026-04-09T08:19:16.151Z" },
 ]
 
 [[package]]
 name = "kikusui-power-supply"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cgse-common" },
     { name = "cgse-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/34/8fd513ae77c2523af199391ed890f82ecae5a7ff3ccc4f88aa35e55d0a41/kikusui_power_supply-0.21.0.tar.gz", hash = "sha256:6990fca38e00f924b59048b111b287563f59dd0f01edf4ce7867108631a796a8", size = 13121, upload-time = "2026-04-02T14:06:09.554Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/af/91e2b5989b9c809a7de7f81435432bc7dfd69b9842fb8de87e999956f3a0/kikusui_power_supply-0.22.0.tar.gz", hash = "sha256:4de1437693b547568ada103c3d8439b4c9a0d88fe7b44448253571260e01e363", size = 13120, upload-time = "2026-04-09T08:19:28.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/5e/209abb668ae356e12345904445ad97b1e9d0613c40191bfcb8ea0ffc4849/kikusui_power_supply-0.21.0-py3-none-any.whl", hash = "sha256:55fcf00749d345c73c9c10074fdf011d8ca38867102a31733935da945d443c1b", size = 17773, upload-time = "2026-04-02T14:06:00.709Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/8d/7d3b89cee0e1eeedcb598094b2cd9c3088147c2fe929c313b204195ee508/kikusui_power_supply-0.22.0-py3-none-any.whl", hash = "sha256:a88c0d2ce0e79a1b6dd27c098e0c2a084dee34d5e8a03fa4781503774fef09da", size = 17773, upload-time = "2026-04-09T08:19:10.713Z" },
 ]
 
 [[package]]
@@ -2001,11 +2012,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
 ]
 
 [[package]]
@@ -2273,20 +2284,20 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.4"
+version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.1"
+version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]
@@ -2867,15 +2878,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -3071,7 +3082,7 @@ wheels = [
 
 [[package]]
 name = "textual"
-version = "8.2.1"
+version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -3081,9 +3092,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/07/766ad19cf2b15cae2d79e0db46a1b783b62316e9ff3e058e7424b2a4398b/textual-8.2.1.tar.gz", hash = "sha256:4176890e9cd5c95dcdd206541b2956b0808e74c8c36381c88db53dcb45237451", size = 1848386, upload-time = "2026-03-29T03:57:32.242Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/2f/d44f0f12b3ddb1f0b88f7775652e99c6b5a43fd733badf4ce064bdbfef4a/textual-8.2.3.tar.gz", hash = "sha256:beea7b86b03b03558a2224f0cc35252e60ef8b0c4353b117b2f40972902d976a", size = 1848738, upload-time = "2026-04-05T09:12:45.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/09/c6f000c2e3702036e593803319af02feee58a662528d0d5728a37e1cf81b/textual-8.2.1-py3-none-any.whl", hash = "sha256:746cbf947a8ca875afc09779ef38cadbc7b9f15ac886a5090f7099fef5ade990", size = 723871, upload-time = "2026-03-29T03:57:34.334Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/28/a81d6ce9f4804818bd1231a9a6e4d56ea84ebbe8385c49591444f0234fa2/textual-8.2.3-py3-none-any.whl", hash = "sha256:5008ac581bebf1f6fa0520404261844a231e5715fdbddd10ca73916a3af48ca2", size = 724231, upload-time = "2026-04-05T09:12:48.747Z" },
 ]
 
 [[package]]
@@ -3335,9 +3346,9 @@ wheels = [
 
 [[package]]
 name = "zipp"
-version = "3.23.0"
+version = "3.23.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
- In the building block and task for the sine sweep, we now also do the configuration of the LabJack (@SiboVG Could you check that it's done correctly and I haven't forgotten any steps?).  The observations now covers a single sine sweep, after which the wave generation and logging of the LabJack are stopped.  Two parameters have been added to their signature (see screenshot below): `strain_gauge` (the SG for which we want logging) and `scan_rate` (the frequency at which this logging is done).  ~Note that - at the end of the observation - all LabJack channels are disabled.~
- For the voltage ramp, we don't need any logging of the strain gauges.

<img width="582" height="518" alt="Screenshot 2026-04-20 at 09 14 52" src="https://github.com/user-attachments/assets/335adc74-4c7b-4aa9-ae29-8f278dd87b96" />
