### PR TITLE
Check safety range for wave generation before configuration

### DIFF
--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -873,6 +873,7 @@ def disable_sg_logging(setup: Setup = None) -> None:
     reset_sg_runtime_settings()
     reset_sg(setup=setup)
 
+
 @building_block
 def disable_sg_channels(setup: Setup = None) -> None:
     """Disables all LabJack channels."""
@@ -882,10 +883,7 @@ def disable_sg_channels(setup: Setup = None) -> None:
 
     for sg_name, sg_info in sg_setup.items():
         set_sg_channel_runtime_settings(
-            sg_name=sg_name,
-            enabled=False,
-            ain_channel=sg_info.ain_channel,
-            setup=setup
+            sg_name=sg_name, enabled=False, ain_channel=sg_info.ain_channel, setup=setup
         )
 
 

--- a/src/tvac/tasks/tvac/piezos/profiles.py
+++ b/src/tvac/tasks/tvac/piezos/profiles.py
@@ -5,8 +5,8 @@ from egse.setup import load_setup
 from gui_executor.exec import exec_ui
 from gui_executor.utypes import Callback
 
+from tvac import wave_generation
 from tvac.tasks.tvac.piezos import profiles
-from tvac.wave_generation import load_voltage_profile
 
 UI_MODULE_DISPLAY_NAME = "2 - Profiles"
 HERE = Path(__file__).parent.parent.resolve()
@@ -15,7 +15,7 @@ ICON_PATH = HERE / "icons/"
 
 # noinspection PyTypeHints
 @exec_ui(display_name="Load profile", use_kernel=True)
-def load_profile(
+def load_voltage_profile(
     profile: Callback(profiles, name="Voltage profile") = None,
 ) -> None:
     """Configures and switches on the Wave Generators for the given voltage profile.
@@ -27,7 +27,7 @@ def load_profile(
     start_observation(f"Voltage profile {profile}")
 
     try:
-        load_voltage_profile(profile=profile, setup=load_setup())
+        wave_generation.load_voltage_profile(profile=profile, setup=load_setup())
     except Exception as e:
         print(
             f"Failed to configure + switch on wave generators, using profile {profile}: {e}"

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -177,6 +177,9 @@ def load_voltage_profile(profile: str, setup: Setup = None) -> None:
 
     setup = setup or load_setup()
     wave_generators_setup = setup.gse.wave_generators
+    min_voltage, max_voltage = map(
+        int, wave_generators_setup.piezo_tests.safety_range.strip("()").split(",")
+    )
 
     awg_list = []
     channel_list = []
@@ -196,6 +199,13 @@ def load_voltage_profile(profile: str, setup: Setup = None) -> None:
     v1_config, v2_config, v3_config, frequency = extract_awg_config_from_setup(
         profile, setup=setup
     )
+
+    for config in (v1_config, v2_config, v3_config):
+        if np.min(config.signal) < min_voltage or np.max(config.signal) > max_voltage:
+            raise ValueError(
+                f"Voltage profile {profile} for piezo actuator {config.name} is outside of the safe range for piezo actuators ({min_voltage} - {max_voltage}V at wave generator level)"
+            )
+
     # We will configure all channels with the requested voltage profile (arbitrary waveform).  Have a look at #52 on
     # more information how this works.
 
@@ -348,6 +358,24 @@ def sine_sweep(
     """
 
     setup = setup or load_setup()
+    min_voltage, max_voltage = map(
+        int, setup.gse.wave_generators.piezo_tests.safety_range.strip("()").split(",")
+    )
+
+    if not min_voltage <= fixed_voltage <= max_voltage:
+        raise ValueError(
+            f"Fixed voltage is outside of the safety range for the piezo actuators ({min_voltage} - {max_voltage}V at "
+            f"wave generator level)"
+        )
+
+    if (
+        dc_offset - amplitude / 2 < min_voltage
+        or dc_offset + amplitude / 2 > max_voltage
+    ):
+        raise ValueError(
+            f"The combination of amplitude and DC offset leads to voltages outside of the safety range for the piezo "
+            f"actuators ({min_voltage} - {max_voltage}V at wave generator level)"
+        )
 
     # Interrupt ongoing logging (this incl. resetting to defaults from the setup)
     # All channels should be disabled -> This may not be the default behaviour from the setup, so do this explicitly
@@ -487,6 +515,15 @@ def ramp(
     """
 
     setup = setup or load_setup()
+    min_voltage, max_voltage = map(
+        int, setup.gse.wave_generators.piezo_tests.safety_range.strip("()").split(",")
+    )
+
+    if not min_voltage <= amplitude <= max_voltage:
+        raise ValueError(
+            f"Given amplitude is outside of the safety range for the piezo actuators ({min_voltage} - {max_voltage}V "
+            f"at wave generator level)"
+        )
 
     # Configure and initiate the voltage ramp (the wave generation stops automatically, but you will still have to
     # reset the wave generators)

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -177,9 +177,7 @@ def load_voltage_profile(profile: str, setup: Setup = None) -> None:
 
     setup = setup or load_setup()
     wave_generators_setup = setup.gse.wave_generators
-    min_voltage, max_voltage = map(
-        int, wave_generators_setup.piezo_tests.safety_range.strip("()").split(",")
-    )
+    min_voltage, max_voltage = setup.gse.wave_generators.piezo_tests.safety_range
 
     awg_list = []
     channel_list = []
@@ -358,9 +356,7 @@ def sine_sweep(
     """
 
     setup = setup or load_setup()
-    min_voltage, max_voltage = map(
-        int, setup.gse.wave_generators.piezo_tests.safety_range.strip("()").split(",")
-    )
+    min_voltage, max_voltage = setup.gse.wave_generators.piezo_tests.safety_range
 
     if not min_voltage <= fixed_voltage <= max_voltage:
         raise ValueError(
@@ -515,9 +511,7 @@ def ramp(
     """
 
     setup = setup or load_setup()
-    min_voltage, max_voltage = map(
-        int, setup.gse.wave_generators.piezo_tests.safety_range.strip("()").split(",")
-    )
+    min_voltage, max_voltage = setup.gse.wave_generators.piezo_tests.safety_range
 
     if not min_voltage <= amplitude <= max_voltage:
         raise ValueError(

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -725,11 +725,15 @@ def check_trigger() -> None:
     """
 
     if not TRIGGER_SETTINGS:
-        print("No settings found for the external trigger.  Please, check your local settings.")
+        print(
+            "No settings found for the external trigger.  Please, check your local settings."
+        )
         return
 
     if "HOSTNAME" not in TRIGGER_SETTINGS or "GPIO" not in TRIGGER_SETTINGS:
-        print("Both the HOSTNAME and GPIO for the external trigger should be present in the settings file.")
+        print(
+            "Both the HOSTNAME and GPIO for the external trigger should be present in the settings file."
+        )
         return
 
     hostname: str = TRIGGER_SETTINGS["HOSTNAME"]

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -201,8 +201,15 @@ def load_voltage_profile(profile: str, setup: Setup = None) -> None:
     for config in (v1_config, v2_config, v3_config):
         if np.min(config.signal) < min_voltage or np.max(config.signal) > max_voltage:
             raise ValueError(
-                f"Voltage profile {profile} for piezo actuator {config.name} is outside of the safe range for piezo actuators ({min_voltage} - {max_voltage}V at wave generator level)"
+                f"Voltage profile {profile} for piezo actuator {config.name} is outside of the safe range for piezo "
+                f"actuators ({min_voltage} - {max_voltage}V at wave generator level)"
             )
+        if config.amplitude == 0:
+            raise ValueError(
+                f"Voltage profile {profile} for piezo actuator {config.name} has an amplitude of 0Vpp, which is not "
+                f"supported"
+            )
+
 
     # We will configure all channels with the requested voltage profile (arbitrary waveform).  Have a look at #52 on
     # more information how this works.
@@ -364,6 +371,12 @@ def sine_sweep(
             f"wave generator level)"
         )
 
+    if amplitude == 0:
+        raise ValueError(
+            f"The amplitude for the sine sweep for piezo actuator {piezo} has an amplitude of 0Vpp, which is not "
+            f"supported"
+        )
+
     if (
         dc_offset - amplitude / 2 < min_voltage
         or dc_offset + amplitude / 2 > max_voltage
@@ -517,6 +530,11 @@ def ramp(
         raise ValueError(
             f"Given amplitude is outside of the safety range for the piezo actuators ({min_voltage} - {max_voltage}V "
             f"at wave generator level)"
+        )
+
+    if amplitude == 0:
+        raise ValueError(
+            f"The amplitude for the voltage ramp has an amplitude of 0Vpp, which is not supported"
         )
 
     # Configure and initiate the voltage ramp (the wave generation stops automatically, but you will still have to


### PR DESCRIPTION
For the sine sweep, ramp, and voltage profile, we check - before the actual configuration - whether the resulting waveform is safe, as defined in the setup.  In this context, see IvS-KULeuven/cubespec-tvac-conf#35.