### PR TITLE
Added missing type cast

### DIFF
--- a/src/tvac/tasks/tvac/piezos/test.py
+++ b/src/tvac/tasks/tvac/piezos/test.py
@@ -126,8 +126,8 @@ def ramp(
 
     try:
         wave_generation.ramp(
-            amplitude=amplitude,
-            period=period,
+            amplitude=float(amplitude),
+            period=float(period),
             piezo_list=list(chain.from_iterable(piezo_list)),
             setup=load_setup(),
         )


### PR DESCRIPTION
This resulted in
```
Failed to ramp voltages up and down for piezo actuators ['V1_V', 'V2_V', 'V3_V']: '<=' not supported between instances of 'int' and 'str'
----- function 'ramp' execution finished.
```