### PR TITLE
Don't split piezo names into characters

### DIFF
--- a/src/tvac/tasks/tvac/piezos/test.py
+++ b/src/tvac/tasks/tvac/piezos/test.py
@@ -2,7 +2,6 @@ from egse.observation import start_observation, end_observation
 from egse.setup import load_setup
 from gui_executor.exec import exec_ui
 from gui_executor.utypes import Callback, DropdownList
-from itertools import chain
 
 from tvac import wave_generation
 from tvac.tasks.tvac.piezos import (
@@ -128,7 +127,7 @@ def ramp(
         wave_generation.ramp(
             amplitude=float(amplitude),
             period=float(period),
-            piezo_list=list(chain.from_iterable(piezo_list)),
+            piezo_list=[piezo_list] if isinstance(piezo_list, str) else list(piezo_list or[]),
             setup=load_setup(),
         )
     except Exception as e:


### PR DESCRIPTION
The UI passes the selected piezo actuators as a list of strings (e.g., `["V1_V", "V2_V"]`). The task wrapper was using `itertools.chain.from_iterable()` to process this list. Because strings are iterable in Python, this incorrectly flattened the strings into individual characters (e.g., `['V', '1', '_', 'V', ...]`). The downstream ramp function then failed with a `KeyError: 'V'` because it was trying to look up an actuator named "V".

Removed the incorrect `chain.from_iterable()` call. Replaced it with a simple type-check that preserves the full string names, safely wrapping single-string UI selections into a list and passing list selections through directly.