### PR TITLE
[UNTESTED] Add `--no-amplifier` command line argument to `tvac_ui`

### DIFF
--- a/src/tvac/runtime_config.py
+++ b/src/tvac/runtime_config.py
@@ -1,0 +1,13 @@
+import os
+
+NO_AMPLIFIER_ENV_VAR = "TVAC_NO_AMPLIFIER"
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def no_amplifier_enabled() -> bool:
+    value = os.environ.get(NO_AMPLIFIER_ENV_VAR, "")
+    return value.strip().lower() in _TRUE_VALUES
+
+
+def set_no_amplifier(enabled: bool) -> None:
+    os.environ[NO_AMPLIFIER_ENV_VAR] = "1" if enabled else "0"

--- a/src/tvac/tasks/tvac/__init__.py
+++ b/src/tvac/tasks/tvac/__init__.py
@@ -1,10 +1,12 @@
+import argparse
 import os
+import shlex
 import sys
 from pathlib import Path
 from executor import ExternalCommand
 import gui_executor.client as client
 
-from gui_executor.__main__ import main as gui_executor_main
+from tvac.runtime_config import set_no_amplifier
 
 HERE = Path(__file__).parent.resolve()
 
@@ -22,11 +24,25 @@ def _resolve_cmd_log_dir() -> str:
     return cmd_log
 
 
+def _parse_tvac_ui_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--no-amplifier",
+        action="store_true",
+        help="Run the piezo UI without the external amplifier in the signal chain.",
+    )
+    return parser.parse_known_args(argv)
+
+
 def tvac_ui():
     client.MyClient.wait_for_ready = _wait_for_ready  # type: ignore[assignment]
+    args, gui_executor_args = _parse_tvac_ui_args(sys.argv[1:])
+    set_no_amplifier(args.no_amplifier)
 
     logo_path = HERE / "icons/dashboard.svg"
     cmd_log = _resolve_cmd_log_dir()
+    passthrough_args = shlex.join(gui_executor_args)
+    passthrough = f" {passthrough_args}" if passthrough_args else ""
 
     cmd = ExternalCommand(
         f"gui-executor --verbose --module-path tvac.tasks.tvac.heaters "
@@ -35,7 +51,7 @@ def tvac_ui():
         f"--module-path tvac.tasks.tvac.observations "
         f"--kernel-name cubespec-tvac-ts --single "
         f"--logo {logo_path} --cmd-log {cmd_log} --app-name 'TVAC GUI' "
-        f"{' '.join(sys.argv[1:])}",
+        f"{passthrough}",
         asynchronous=True,
     )
     cmd.start()

--- a/src/tvac/tasks/tvac/piezos/__init__.py
+++ b/src/tvac/tasks/tvac/piezos/__init__.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from egse.setup import load_setup
+from tvac.runtime_config import no_amplifier_enabled
 
 UI_TAB_DISPLAY_NAME = "Piezo Actuators"
 
@@ -54,7 +55,8 @@ def sine_sweep_amplitude() -> float:
 
 
 def sine_sweep_dc_offset() -> float:
-    return _sine_sweep_param("dc_offset")
+    dc_offset = _sine_sweep_param("dc_offset")
+    return dc_offset * 20.0 if no_amplifier_enabled() else dc_offset
 
 
 def sine_sweep_start_frequency() -> float:
@@ -70,7 +72,8 @@ def sine_sweep_time() -> float:
 
 
 def sine_sweep_fixed_voltage() -> float:
-    return _sine_sweep_param("fixed_voltage")
+    fixed_voltage = _sine_sweep_param("fixed_voltage")
+    return fixed_voltage * 20.0 if no_amplifier_enabled() else fixed_voltage
 
 
 def _sine_sweep_labjack_logging_param(param: str) -> float:
@@ -104,6 +107,10 @@ def _ramp_param(param: str) -> float:
 
 
 def ramp_amplitude() -> float:
+    if no_amplifier_enabled():
+        # We normally wanted 10 V here, but the AWG cannot output this unless the
+        # output load is set to OPEN instead of 50 Ohm.
+        return 5.0
     return _ramp_param("amplitude")
 
 

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -18,6 +18,7 @@ from egse.observation import building_block
 from egse.settings import Settings
 from egse.setup import load_setup, Setup
 
+from tvac.runtime_config import no_amplifier_enabled
 from tvac.strain_gauge import (
     disable_sg_logging,
     enable_sg_logging,
@@ -184,8 +185,6 @@ def load_voltage_profile(profile: str, setup: Setup = None) -> None:
     setup = setup or load_setup()
     # noinspection PyUnresolvedReferences
     wave_generators_setup = setup.gse.wave_generators
-    # noinspection PyUnresolvedReferences
-    min_voltage, max_voltage = setup.gse.wave_generators.piezo_tests.safety_range
 
     awg_list = []
     channel_list = []
@@ -207,11 +206,14 @@ def load_voltage_profile(profile: str, setup: Setup = None) -> None:
     )
 
     for config in (v1_config, v2_config, v3_config):
-        if np.min(config.signal) < min_voltage or np.max(config.signal) > max_voltage:
-            raise ValueError(
-                f"Voltage profile {profile} for piezo actuator {config.name} is outside of the safe range for piezo "
-                f"actuators ({min_voltage} - {max_voltage}V at wave generator level)"
-            )
+        if not no_amplifier_enabled():
+            # noinspection PyUnresolvedReferences
+            min_voltage, max_voltage = setup.gse.wave_generators.piezo_tests.safety_range
+            if np.min(config.signal) < min_voltage or np.max(config.signal) > max_voltage:
+                raise ValueError(
+                    f"Voltage profile {profile} for piezo actuator {config.name} is outside of the safe range for piezo "
+                    f"actuators ({min_voltage} - {max_voltage}V at wave generator level)"
+                )
         if config.amplitude == 0:
             raise ValueError(
                 f"Voltage profile {profile} for piezo actuator {config.name} has an amplitude of 0Vpp, which is not "
@@ -384,17 +386,9 @@ def sine_sweep(
 
     setup = setup or load_setup()
     # noinspection PyUnresolvedReferences
-    min_voltage, max_voltage = setup.gse.wave_generators.piezo_tests.safety_range
-    # noinspection PyUnresolvedReferences
     sine_sweep_labjack_logging = (
         setup.gse.wave_generators.piezo_tests.sine_sweep.labjack_logging
     )
-
-    if not min_voltage <= fixed_voltage <= max_voltage:
-        raise ValueError(
-            f"Fixed voltage is outside of the safety range for the piezo actuators ({min_voltage} - {max_voltage}V at "
-            f"wave generator level)"
-        )
 
     if amplitude == 0:
         raise ValueError(
@@ -402,14 +396,24 @@ def sine_sweep(
             f"supported"
         )
 
-    if (
-        dc_offset - amplitude / 2 < min_voltage
-        or dc_offset + amplitude / 2 > max_voltage
-    ):
-        raise ValueError(
-            f"The combination of amplitude and DC offset leads to voltages outside of the safety range for the piezo "
-            f"actuators ({min_voltage} - {max_voltage}V at wave generator level)"
-        )
+    if not no_amplifier_enabled():
+        # noinspection PyUnresolvedReferences
+        min_voltage, max_voltage = setup.gse.wave_generators.piezo_tests.safety_range
+
+        if not min_voltage <= fixed_voltage <= max_voltage:
+            raise ValueError(
+                f"Fixed voltage is outside of the safety range for the piezo actuators ({min_voltage} - {max_voltage}V at "
+                f"wave generator level)"
+            )
+
+        if (
+            dc_offset - amplitude / 2 < min_voltage
+            or dc_offset + amplitude / 2 > max_voltage
+        ):
+            raise ValueError(
+                f"The combination of amplitude and DC offset leads to voltages outside of the safety range for the piezo "
+                f"actuators ({min_voltage} - {max_voltage}V at wave generator level)"
+            )
 
     # Interrupt ongoing logging (this incl. resetting to defaults from the setup)
     # All channels should be disabled -> This may not be the default behaviour from the setup, so do this explicitly
@@ -559,18 +563,20 @@ def ramp(
     """
 
     setup = setup or load_setup()
-    # noinspection PyUnresolvedReferences
-    min_voltage, max_voltage = setup.gse.wave_generators.piezo_tests.safety_range
 
-    if not min_voltage <= amplitude <= max_voltage:
-        raise ValueError(
-            f"Given amplitude is outside of the safety range for the piezo actuators ({min_voltage} - {max_voltage}V "
-            f"at wave generator level)"
-        )
+    if not no_amplifier_enabled():
+        # noinspection PyUnresolvedReferences
+        min_voltage, max_voltage = setup.gse.wave_generators.piezo_tests.safety_range
+
+        if not min_voltage <= amplitude <= max_voltage:
+            raise ValueError(
+                f"Given amplitude is outside of the safety range for the piezo actuators ({min_voltage} - {max_voltage}V "
+                f"at wave generator level)"
+            )
 
     if amplitude == 0:
         raise ValueError(
-            f"The amplitude for the voltage ramp has an amplitude of 0Vpp, which is not supported"
+            "The amplitude for the voltage ramp has an amplitude of 0Vpp, which is not supported"
         )
 
     # Interrupt ongoing logging (this incl. resetting to defaults from the setup) and re-start logging with the


### PR DESCRIPTION
We've decided to not use the PiezoDrive PDu150 amplifier for the ramp signal generation and sine sweep, because it attenuates the signal at higher frequencies (for the capacitive load of the piezo actuator, the -3 dB cutoff frequency is ≈ 1 kHz). Instead, the AWG drives the actuator directly.

In effect, this means that we must amplify the current AWG signal by 20 (the gain of the amplifier). This PR adds a `--no-amplifier` command line argument to the `tvac_ui` command which:
- Multiplies the sine sweep amplitude, dc_offset, and the fixed voltage from the setup file by 20
- Set the ramp amplitude to 5. Ideally, this would've also amplified the setup file value by 20, but that would mean an output voltage of 10 V. This is not possible on the AWG, unless you set the output load to `OPEN` instead of `50` (Ohm). But, a ramp of 5 V is also fine.
- Bypasses the safety checks for the AWG signal, since those limits were set for an amplified signal

I deliberately decided to not do this with shell-wide env vars, because there is a very real risk of us forgetting to disable that var when we add back the amplifier. It's good to have some self awareness 🙂 .

These changes are yet to be tested on the EGSE, since we are currently running a non-op thermal cycle.

---

In short, when we run tests where the piezo amplifier is connected, run with `tvac_ui`. When the amplifier is not connected, run with `tvac_ui --no-amplifier`.