### PR TITLE
Double the duration of the sine sweep building block

### DIFF
--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -464,8 +464,10 @@ def sine_sweep(
     )
 
     # Let the sine sweep go on for the requested duration
+    # Since the sine sweep starts at random time in the sweep, we let it go on for twice the requested duration, to
+    # ensure that we get at least one full sine sweep.
 
-    time.sleep(float(sweep_time))
+    time.sleep(2 * float(sweep_time))
 
     # Stop the wave generation + reset the wave generators
 


### PR DESCRIPTION
Since the original proposed solution for #94 did not suffice, we double the duration of the sine sweep building block to make sure we cover at least one full sine sweep.