### PR TITLE
Use stream resolution index from config instead of fixed 0

### DIFF
--- a/src/tvac/labjack_t7.py
+++ b/src/tvac/labjack_t7.py
@@ -146,7 +146,6 @@ class LabJackT7Logger:
             voltage_range=voltage_ranges,
             neg_voltage_range=neg_voltage_ranges,
             resolution_index=resolution_indices,
-            stream_resolution_index=getattr(stream, "stream_resolution_index", 0),
             resync_interval_s=stream.resync_interval_s,
             buffer_size=stream.buffer_size,
         )

--- a/src/tvac/labjack_t7.py
+++ b/src/tvac/labjack_t7.py
@@ -39,7 +39,9 @@ class LabJackT7Logger:
         Voltage range for negative reference channels. Scalar or
         per-channel list. Default 10.0 V.
     resolution_index : int | list[int]
-        Stream resolution index. Scalar or per-channel list. 0 = auto.
+        Analog-input resolution index. Scalar or per-channel list. 0 = auto.
+    stream_resolution_index : int
+        Stream-wide resolution index. 0 = auto.
     resync_interval_s : int
         Seconds between host-clock re-anchor points to limit drift.
     buffer_size : int
@@ -69,6 +71,7 @@ class LabJackT7Logger:
         voltage_range: float | list[float] = 0.1,
         neg_voltage_range: float | list[float] = 10.0,
         resolution_index: int | list[int] = 0,
+        stream_resolution_index: int = 0,
         resync_interval_s: int = 60,
         buffer_size: int = 32768,
     ):
@@ -76,6 +79,7 @@ class LabJackT7Logger:
         self.scan_rate = scan_rate
         self.resync_interval_s = resync_interval_s
         self.buffer_size = buffer_size
+        self.stream_resolution_index = int(stream_resolution_index)
 
         n = len(ain_channels)
         self.voltage_ranges = self._expand(voltage_range, n, "voltage_range")
@@ -142,6 +146,7 @@ class LabJackT7Logger:
             voltage_range=voltage_ranges,
             neg_voltage_range=neg_voltage_ranges,
             resolution_index=resolution_indices,
+            stream_resolution_index=getattr(stream, "stream_resolution_index", 0),
             resync_interval_s=stream.resync_interval_s,
             buffer_size=stream.buffer_size,
         )
@@ -212,7 +217,7 @@ class LabJackT7Logger:
         values += [
             0,  # free-running
             0,  # internal clock
-            0,  # stream-level resolution (per-channel set above)
+            self.stream_resolution_index,
             0.0,  # auto settling (float < 1)
             0,  # continuous
             self.buffer_size,

--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -181,7 +181,9 @@ def _snapshot_setup_cfg(setup: Setup) -> dict[str, dict[str, Any]]:
     return {
         "stream": {
             "scan_rate": cfg.stream.scan_rate,
-            "stream_resolution_index": getattr(cfg.stream, "stream_resolution_index", 0),
+            # Not a setup.gse.labjack_t7.stream field. Piezo tests can override
+            # this per measurement through in-memory runtime settings.
+            "stream_resolution_index": 0,
             "resync_interval_s": cfg.stream.resync_interval_s,
             "buffer_size": cfg.stream.buffer_size,
         },
@@ -431,7 +433,6 @@ def get_sg_settings(setup: Setup = None) -> str:
         (
             "stream: "
             f"scan_rate={effective['stream']['scan_rate']}, "
-            f"stream_resolution_index={effective['stream']['stream_resolution_index']}, "
             f"resync_interval_s={effective['stream']['resync_interval_s']}, "
             f"buffer_size={effective['stream']['buffer_size']}"
         ),
@@ -712,7 +713,6 @@ def start_sg_logging(setup: Setup = None):
         "starting stream "
         f"channels={_active_channel_labels} "
         f"scan_rate={effective['stream']['scan_rate']} "
-        f"stream_resolution_index={effective['stream']['stream_resolution_index']} "
         f"plot_enabled={effective['plot']['enabled']} "
         f"csv_enabled={effective['csv']['enabled']}"
         f"metrics_enabled={effective['metrics']['enabled']}",
@@ -868,11 +868,7 @@ def enable_all_sg_logging(
 
     set_sg_runtime_settings(
         scan_rate=stream_setup.scan_rate,
-        stream_resolution_index=(
-            stream_resolution_index
-            if stream_resolution_index is not None
-            else getattr(stream_setup, "stream_resolution_index", 0)
-        ),
+        stream_resolution_index=stream_resolution_index,
         resync_interval_s=stream_setup.resync_interval_s,
         buffer_size=stream_setup.buffer_size,
         csv_enabled=True,
@@ -946,11 +942,7 @@ def enable_sg_logging(
 
     set_sg_runtime_settings(
         scan_rate=scan_rate,
-        stream_resolution_index=(
-            stream_resolution_index
-            if stream_resolution_index is not None
-            else getattr(stream_setup, "stream_resolution_index", 0)
-        ),
+        stream_resolution_index=stream_resolution_index,
         resync_interval_s=stream_setup.resync_interval_s,
         buffer_size=stream_setup.buffer_size,
         csv_enabled=True,
@@ -1025,7 +1017,6 @@ def reset_sg(setup: Setup = None) -> None:
 
     set_sg_runtime_settings(
         scan_rate=stream_setup.scan_rate,
-        stream_resolution_index=getattr(stream_setup, "stream_resolution_index", 0),
         resync_interval_s=stream_setup.resync_interval_s,
         buffer_size=stream_setup.buffer_size,
         csv_enabled=csv_setup.enabled,

--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -181,6 +181,7 @@ def _snapshot_setup_cfg(setup: Setup) -> dict[str, dict[str, Any]]:
     return {
         "stream": {
             "scan_rate": cfg.stream.scan_rate,
+            "stream_resolution_index": getattr(cfg.stream, "stream_resolution_index", 0),
             "resync_interval_s": cfg.stream.resync_interval_s,
             "buffer_size": cfg.stream.buffer_size,
         },
@@ -280,6 +281,7 @@ def get_cached_sg_channel_settings() -> dict[str, dict[str, Any]]:
 def set_sg_runtime_settings(
     *,
     scan_rate=None,
+    stream_resolution_index=None,
     resync_interval_s=None,
     buffer_size=None,
     csv_enabled=None,
@@ -300,6 +302,12 @@ def set_sg_runtime_settings(
     if scan_rate is not None:
         _runtime_overrides["stream"]["scan_rate"] = _coerce_positive_float(
             scan_rate, "scan_rate"
+        )
+    if stream_resolution_index is not None:
+        _runtime_overrides["stream"]["stream_resolution_index"] = (
+            _coerce_non_negative_int(
+                stream_resolution_index, "stream_resolution_index"
+            )
         )
     if resync_interval_s is not None:
         _runtime_overrides["stream"]["resync_interval_s"] = _coerce_positive_int(
@@ -423,6 +431,7 @@ def get_sg_settings(setup: Setup = None) -> str:
         (
             "stream: "
             f"scan_rate={effective['stream']['scan_rate']}, "
+            f"stream_resolution_index={effective['stream']['stream_resolution_index']}, "
             f"resync_interval_s={effective['stream']['resync_interval_s']}, "
             f"buffer_size={effective['stream']['buffer_size']}"
         ),
@@ -686,6 +695,7 @@ def start_sg_logging(setup: Setup = None):
             voltage_range=voltage_ranges,
             neg_voltage_range=neg_voltage_ranges,
             resolution_index=resolution_indices,
+            stream_resolution_index=int(effective["stream"]["stream_resolution_index"]),
             resync_interval_s=int(effective["stream"]["resync_interval_s"]),
             buffer_size=int(effective["stream"]["buffer_size"]),
         )
@@ -702,6 +712,7 @@ def start_sg_logging(setup: Setup = None):
         "starting stream "
         f"channels={_active_channel_labels} "
         f"scan_rate={effective['stream']['scan_rate']} "
+        f"stream_resolution_index={effective['stream']['stream_resolution_index']} "
         f"plot_enabled={effective['plot']['enabled']} "
         f"csv_enabled={effective['csv']['enabled']}"
         f"metrics_enabled={effective['metrics']['enabled']}",
@@ -853,6 +864,7 @@ def enable_all_sg_logging(setup: Setup = None) -> None:
 
     set_sg_runtime_settings(
         scan_rate=stream_setup.scan_rate,
+        stream_resolution_index=getattr(stream_setup, "stream_resolution_index", 0),
         resync_interval_s=stream_setup.resync_interval_s,
         buffer_size=stream_setup.buffer_size,
         csv_enabled=True,
@@ -871,7 +883,8 @@ def enable_sg_logging(
     neg_voltage_range,
     resolution_index: int,
     scan_rate: float,
-    setup: Setup,
+    setup: Setup = None,
+    stream_resolution_index: int | None = None,
 ) -> None:
     """Enables the logging for the given strain gauge.
 
@@ -893,6 +906,7 @@ def enable_sg_logging(
         resolution_index (int): Resolution index of the strain gauge [m].
         scan_rate (float): Scan rate of the strain gauge [Hz].
         setup (Setup): Setup.
+        stream_resolution_index (int | None): Stream-wide resolution index [m].
     """
 
     setup = setup or load_setup()
@@ -924,6 +938,11 @@ def enable_sg_logging(
 
     set_sg_runtime_settings(
         scan_rate=scan_rate,
+        stream_resolution_index=(
+            stream_resolution_index
+            if stream_resolution_index is not None
+            else getattr(stream_setup, "stream_resolution_index", 0)
+        ),
         resync_interval_s=stream_setup.resync_interval_s,
         buffer_size=stream_setup.buffer_size,
         csv_enabled=True,
@@ -998,6 +1017,7 @@ def reset_sg(setup: Setup = None) -> None:
 
     set_sg_runtime_settings(
         scan_rate=stream_setup.scan_rate,
+        stream_resolution_index=getattr(stream_setup, "stream_resolution_index", 0),
         resync_interval_s=stream_setup.resync_interval_s,
         buffer_size=stream_setup.buffer_size,
         csv_enabled=csv_setup.enabled,

--- a/src/tvac/strain_gauge.py
+++ b/src/tvac/strain_gauge.py
@@ -820,13 +820,17 @@ def trim_plot_buffers(keep_seconds: float):
 
 
 @building_block
-def enable_all_sg_logging(setup: Setup = None) -> None:
+def enable_all_sg_logging(
+    setup: Setup = None,
+    stream_resolution_index: int | None = None,
+) -> None:
     """Enables the logging for the all strain gauge.
 
     The following steps are performed:
 
         - For all strain gauges, set the voltage ranges and resolution index (from the setup), and enable its
           channel,
+        - Set the stream resolution index override when provided,
         - Enable HK and metrics,
         - Make sure that the HK ends up in the folder, dedicated to the current observation, and that the filenames
           also refer to the current observation (since this function is a building block, it can only be run in the
@@ -864,7 +868,11 @@ def enable_all_sg_logging(setup: Setup = None) -> None:
 
     set_sg_runtime_settings(
         scan_rate=stream_setup.scan_rate,
-        stream_resolution_index=getattr(stream_setup, "stream_resolution_index", 0),
+        stream_resolution_index=(
+            stream_resolution_index
+            if stream_resolution_index is not None
+            else getattr(stream_setup, "stream_resolution_index", 0)
+        ),
         resync_interval_s=stream_setup.resync_interval_s,
         buffer_size=stream_setup.buffer_size,
         csv_enabled=True,

--- a/src/tvac/tasks/tvac/piezos/__init__.py
+++ b/src/tvac/tasks/tvac/piezos/__init__.py
@@ -11,7 +11,11 @@ def profiles() -> List[str]:
 
     setup = load_setup()
 
-    return list(setup.gse.wave_generators.piezo_tests.profiles.keys())
+    return [
+        profile
+        for profile in setup.gse.wave_generators.piezo_tests.profiles.keys()
+        if profile != "labjack_logging"
+    ]
 
 
 def piezos() -> List[str]:

--- a/src/tvac/tasks/tvac/strain_gauges/__init__.py
+++ b/src/tvac/tasks/tvac/strain_gauges/__init__.py
@@ -45,10 +45,6 @@ def sg_scan_rate() -> float:
     return float(get_sg_effective_settings()["stream"]["scan_rate"])
 
 
-def sg_stream_resolution_index() -> int:
-    return int(get_sg_effective_settings()["stream"]["stream_resolution_index"])
-
-
 def sg_resync_interval_s() -> int:
     return int(get_sg_effective_settings()["stream"]["resync_interval_s"])
 

--- a/src/tvac/tasks/tvac/strain_gauges/__init__.py
+++ b/src/tvac/tasks/tvac/strain_gauges/__init__.py
@@ -45,6 +45,10 @@ def sg_scan_rate() -> float:
     return float(get_sg_effective_settings()["stream"]["scan_rate"])
 
 
+def sg_stream_resolution_index() -> int:
+    return int(get_sg_effective_settings()["stream"]["stream_resolution_index"])
+
+
 def sg_resync_interval_s() -> int:
     return int(get_sg_effective_settings()["stream"]["resync_interval_s"])
 

--- a/src/tvac/tasks/tvac/strain_gauges/strain_gauges.py
+++ b/src/tvac/tasks/tvac/strain_gauges/strain_gauges.py
@@ -28,7 +28,6 @@ from tvac.tasks.tvac.strain_gauges import (
     sg_plot_window_seconds,
     sg_resync_interval_s,
     sg_scan_rate,
-    sg_stream_resolution_index,
     strain_gauges,
     voltage_ranges,
     resolution_indices,
@@ -183,9 +182,6 @@ def configure_sg_channels(
 @exec_ui(display_name="Configure stream", use_kernel=True)
 def configure_stream(
     scan_rate: Callback(sg_scan_rate, name="Scan rate [Hz]") = None,
-    stream_resolution_index: Callback(
-        sg_stream_resolution_index, name="Stream resolution index"
-    ) = None,
     resync_interval_s: Callback(
         sg_resync_interval_s, name="Resync interval [s]"
     ) = None,
@@ -195,7 +191,6 @@ def configure_stream(
     try:
         set_sg_runtime_settings(
             scan_rate=float(scan_rate),
-            stream_resolution_index=int(stream_resolution_index),
             resync_interval_s=int(resync_interval_s),
             buffer_size=int(buffer_size),
         )

--- a/src/tvac/tasks/tvac/strain_gauges/strain_gauges.py
+++ b/src/tvac/tasks/tvac/strain_gauges/strain_gauges.py
@@ -7,7 +7,6 @@ from gui_executor.utypes import Callback, TypeObject, UQWidget
 
 from tvac.strain_gauge import (
     get_cached_sg_channel_settings,
-    get_sg_channel_names,
     get_sg_effective_settings,
     get_sg_settings,
     get_sg_status,
@@ -29,6 +28,7 @@ from tvac.tasks.tvac.strain_gauges import (
     sg_plot_window_seconds,
     sg_resync_interval_s,
     sg_scan_rate,
+    sg_stream_resolution_index,
     strain_gauges,
     voltage_ranges,
     resolution_indices,
@@ -183,6 +183,9 @@ def configure_sg_channels(
 @exec_ui(display_name="Configure stream", use_kernel=True)
 def configure_stream(
     scan_rate: Callback(sg_scan_rate, name="Scan rate [Hz]") = None,
+    stream_resolution_index: Callback(
+        sg_stream_resolution_index, name="Stream resolution index"
+    ) = None,
     resync_interval_s: Callback(
         sg_resync_interval_s, name="Resync interval [s]"
     ) = None,
@@ -192,6 +195,7 @@ def configure_stream(
     try:
         set_sg_runtime_settings(
             scan_rate=float(scan_rate),
+            stream_resolution_index=int(stream_resolution_index),
             resync_interval_s=int(resync_interval_s),
             buffer_size=int(buffer_size),
         )

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -237,7 +237,12 @@ def load_voltage_profile(profile: str, setup: Setup = None) -> None:
     # default configuration (except for the output folder and filenames: these should pertain to the obsid)
 
     disable_sg_logging(setup=setup)
-    enable_all_sg_logging(setup=setup)
+    enable_all_sg_logging(
+        setup=setup,
+        stream_resolution_index=_piezo_test_stream_resolution_index(
+            piezo_tests_setup.profiles
+        ),
+    )
 
     # We will configure all channels with the requested voltage profile (arbitrary waveform).  Have a look at #52 on
     # more information how this works.
@@ -360,7 +365,13 @@ def extract_awg_config_from_setup(profile: str, setup: Setup = None):
 
 def _piezo_test_stream_resolution_index(test_setup) -> int:
     """Return the LabJack stream resolution index for one piezo test."""
-    labjack_logging = getattr(test_setup, "labjack_logging", None)
+    if isinstance(test_setup, dict):
+        labjack_logging = test_setup.get("labjack_logging")
+    else:
+        labjack_logging = getattr(test_setup, "labjack_logging", None)
+
+    if isinstance(labjack_logging, dict):
+        return int(labjack_logging.get("stream_resolution_index", 0))
     return int(getattr(labjack_logging, "stream_resolution_index", 0))
 
 

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -358,6 +358,12 @@ def extract_awg_config_from_setup(profile: str, setup: Setup = None):
     return v1_config, v2_config, v3_config, frequency
 
 
+def _piezo_test_stream_resolution_index(test_setup) -> int:
+    """Return the LabJack stream resolution index for one piezo test."""
+    labjack_logging = getattr(test_setup, "labjack_logging", None)
+    return int(getattr(labjack_logging, "stream_resolution_index", 0))
+
+
 @building_block
 def sine_sweep(
     piezo: str,
@@ -448,8 +454,8 @@ def sine_sweep(
         resolution_index=sine_sweep_labjack_logging.resolution_index,
         scan_rate=scan_rate,
         setup=setup,
-        stream_resolution_index=getattr(
-            sine_sweep_labjack_logging, "stream_resolution_index", 0
+        stream_resolution_index=_piezo_test_stream_resolution_index(
+            piezo_tests_setup.sine_sweep
         ),
     )
 
@@ -622,7 +628,12 @@ def ramp(
     # default configuration (except for the output folder and filenames: these should pertain to the obsid)
 
     disable_sg_logging(setup=setup)
-    enable_all_sg_logging(setup=setup)
+    enable_all_sg_logging(
+        setup=setup,
+        stream_resolution_index=_piezo_test_stream_resolution_index(
+            piezo_tests_setup.ramp
+        ),
+    )
 
     # Configure and initiate the voltage ramp (the wave generation stops automatically, but you will still have to
     # reset the wave generators)
@@ -770,13 +781,18 @@ def plateau(
         )
 
     if voltage == 0:
-        raise ValueError(f"Plateau for piezo actuators is 0V, which is not supported")
+        raise ValueError("Plateau for piezo actuators is 0V, which is not supported")
 
     # Interrupt ongoing logging (this incl. resetting to defaults from the setup) and re-start logging with the
     # default configuration (except for the output folder and filenames: these should pertain to the obsid)
 
     disable_sg_logging(setup=setup)
-    enable_all_sg_logging(setup=setup)
+    enable_all_sg_logging(
+        setup=setup,
+        stream_resolution_index=_piezo_test_stream_resolution_index(
+            piezo_tests_setup.plateau
+        ),
+    )
 
     for awg, channel in zip(awg_list, channel_list):
         awg.set_channel(channel)

--- a/src/tvac/wave_generation.py
+++ b/src/tvac/wave_generation.py
@@ -448,6 +448,9 @@ def sine_sweep(
         resolution_index=sine_sweep_labjack_logging.resolution_index,
         scan_rate=scan_rate,
         setup=setup,
+        stream_resolution_index=getattr(
+            sine_sweep_labjack_logging, "stream_resolution_index", 0
+        ),
     )
 
     # Configure and initiate the sine sweep (keeps on going until the wave generation is stopped explicitly)


### PR DESCRIPTION
In a recent FSM characterisation test with the LabJack, we noticed that we could greatly decrease the noise of the output by setting `STREAM_RESOLUTION_INDEX` to `5`. In the current EGSE code, this value is set to a fixed value of `0`. This PR takes the stream resolution index from the setup (see https://github.com/IvS-KULeuven/cubespec-tvac-conf/pull/44) and uses that instead.